### PR TITLE
Refactor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,8 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install dev dependencies
-        run: python -m pip install appdirs==1.4.4
+        # Forked commit
+        run: python -m pip install https://github.com/ActiveState/appdirs/archive/8eacfa312d77aba28d483fbfb6f6fc54099622be.zip
 
       - name: Run tests
         run: python -m unittest discover

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,5 +33,8 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - name: Install dev dependencies
+        run: python -m pip install appdirs==1.4.4
+
       - name: Run tests
         run: python -m unittest discover

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/.idea/
+/.vscode/
+
 *.pyc
 *.egg-info
 tmp/

--- a/platformdirs.py
+++ b/platformdirs.py
@@ -269,9 +269,11 @@ elif system == 'darwin':
         return _user_data_dir_impl(appname=appname, appauthor=appauthor, version=version, roaming=roaming)
 
     def _user_log_dir_impl(appname=None, appauthor=None, version=None, opinion=True):
-        path = os.path.join(os.path.expanduser('~/Library/Logs'), appname)
-        if appname and version:
-            path = os.path.join(path, version)
+        path = os.path.expanduser('~/Library/Logs')
+        if appname:
+            path = os.path.join(path, appname)
+            if version:
+                path = os.path.join(path, version)
 
         return path
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,6 +1,7 @@
 import sys
 import unittest
 import platformdirs
+import appdirs
 
 if sys.version_info[0] < 3:
     STRING_TYPE = basestring
@@ -32,6 +33,45 @@ class Test_PlatformDirs(unittest.TestCase):
         self.assertIsInstance(dirs.user_cache_dir, STRING_TYPE)
         self.assertIsInstance(dirs.user_state_dir, STRING_TYPE)
         self.assertIsInstance(dirs.user_log_dir, STRING_TYPE)
+
+    def test_backward_compatibility_basic(self):
+        self.assertEqual(platformdirs.user_data_dir(), appdirs.user_data_dir())
+        self.assertEqual(platformdirs.site_data_dir(), appdirs.site_data_dir())
+        self.assertEqual(platformdirs.user_config_dir(), appdirs.user_config_dir())
+        self.assertEqual(platformdirs.site_config_dir(), appdirs.site_config_dir())
+        self.assertEqual(platformdirs.user_cache_dir(), appdirs.user_cache_dir())
+        self.assertEqual(platformdirs.user_state_dir(), appdirs.user_state_dir())
+        self.assertEqual(platformdirs.user_log_dir(), appdirs.user_log_dir())
+
+    def test_backward_compatibility_appname(self):
+        kwargs = {'appname': 'foo'}
+        self.assertEqual(platformdirs.user_data_dir(**kwargs), appdirs.user_data_dir(**kwargs))
+        self.assertEqual(platformdirs.site_data_dir(**kwargs), appdirs.site_data_dir(**kwargs))
+        self.assertEqual(platformdirs.user_config_dir(**kwargs), appdirs.user_config_dir(**kwargs))
+        self.assertEqual(platformdirs.site_config_dir(**kwargs), appdirs.site_config_dir(**kwargs))
+        self.assertEqual(platformdirs.user_cache_dir(**kwargs), appdirs.user_cache_dir(**kwargs))
+        self.assertEqual(platformdirs.user_state_dir(**kwargs), appdirs.user_state_dir(**kwargs))
+        self.assertEqual(platformdirs.user_log_dir(**kwargs), appdirs.user_log_dir(**kwargs))
+
+    def test_backward_compatibility_appname_appauthor(self):
+        kwargs = {'appname': 'foo', 'appauthor': 'bar'}
+        self.assertEqual(platformdirs.user_data_dir(**kwargs), appdirs.user_data_dir(**kwargs))
+        self.assertEqual(platformdirs.site_data_dir(**kwargs), appdirs.site_data_dir(**kwargs))
+        self.assertEqual(platformdirs.user_config_dir(**kwargs), appdirs.user_config_dir(**kwargs))
+        self.assertEqual(platformdirs.site_config_dir(**kwargs), appdirs.site_config_dir(**kwargs))
+        self.assertEqual(platformdirs.user_cache_dir(**kwargs), appdirs.user_cache_dir(**kwargs))
+        self.assertEqual(platformdirs.user_state_dir(**kwargs), appdirs.user_state_dir(**kwargs))
+        self.assertEqual(platformdirs.user_log_dir(**kwargs), appdirs.user_log_dir(**kwargs))
+
+    def test_backward_compatibility_appname_appauthor_version(self):
+        kwargs = {'appname': 'foo', 'appauthor': 'bar', 'version': 'v1.0'}
+        self.assertEqual(platformdirs.user_data_dir(**kwargs), appdirs.user_data_dir(**kwargs))
+        self.assertEqual(platformdirs.site_data_dir(**kwargs), appdirs.site_data_dir(**kwargs))
+        self.assertEqual(platformdirs.user_config_dir(**kwargs), appdirs.user_config_dir(**kwargs))
+        self.assertEqual(platformdirs.site_config_dir(**kwargs), appdirs.site_config_dir(**kwargs))
+        self.assertEqual(platformdirs.user_cache_dir(**kwargs), appdirs.user_cache_dir(**kwargs))
+        self.assertEqual(platformdirs.user_state_dir(**kwargs), appdirs.user_state_dir(**kwargs))
+        self.assertEqual(platformdirs.user_log_dir(**kwargs), appdirs.user_log_dir(**kwargs))
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -41,7 +41,12 @@ class Test_PlatformDirs(unittest.TestCase):
         self.assertEqual(platformdirs.site_config_dir(), appdirs.site_config_dir())
         self.assertEqual(platformdirs.user_cache_dir(), appdirs.user_cache_dir())
         self.assertEqual(platformdirs.user_state_dir(), appdirs.user_state_dir())
-        self.assertEqual(platformdirs.user_log_dir(), appdirs.user_log_dir())
+
+        # Calling `appdirs.user_log_dir` without appname produces NoneType error on macOS
+        if sys.platform == 'darwin':
+            self.assertTrue(isinstance(platformdirs.user_log_dir(), str))
+        else:
+            self.assertEqual(platformdirs.user_log_dir(), appdirs.user_log_dir())
 
     def test_backward_compatibility_appname(self):
         kwargs = {'appname': 'foo'}

--- a/tox.ini
+++ b/tox.ini
@@ -3,5 +3,6 @@ envlist = py{27,py,35,36,37,38,39,py3}
 
 [testenv]
 deps =
-    appdirs==1.4.4
+    ; Forked commit
+    https://github.com/ActiveState/appdirs/archive/8eacfa312d77aba28d483fbfb6f6fc54099622be.zip
 commands = {envpython} -m unittest discover

--- a/tox.ini
+++ b/tox.ini
@@ -2,4 +2,6 @@
 envlist = py{27,py,35,36,37,38,39,py3}
 
 [testenv]
+deps =
+    appdirs==1.4.4
 commands = {envpython} -m unittest discover


### PR DESCRIPTION
Changes:

1. Put conditional platform logic at the module level rather than within each function, speeding up calls and making the code much easier to maintain
2. Removed 2 erroneous calls to `os.path.expanduser` on macOS
3. Converted temporary `dict` creations on some Windows logic to `if` branches
4. Converted `os.getenv` calls with defaults to checking existence in `os.environ`