### PR TITLE
Add missing entries to the changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ platformdirs 2.0.0
 - **BREAKING** Name change as part of the friendly fork
 - **BREAKING** Remove support for end-of-life Pythons 2.6, 3.2, and 3.3
 - **BREAKING** Correct the config directory on OSX/macOS
-- Add Python 3.7 support
+- Add Python 3.7, 3.8, and 3.9 support
 
 appdirs 1.4.4
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,12 +6,12 @@ platformdirs 2.0.0
 
 - **BREAKING** Name change as part of the friendly fork
 - **BREAKING** Remove support for end-of-life Pythons 2.6, 3.2, and 3.3
+- **BREAKING** Correct the config directory on OSX/macOS
 - Add Python 3.7 support
 
 appdirs 1.4.4
 -------------
 - [PR #92] Don't import appdirs from setup.py which resolves issue #91
-- [PR #100] Corrects the config directory on OSX/macOS, which resolves issue #63.
 
 Project officially classified as Stable which is important
 for inclusion in other distros such as ActivePython.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,9 @@ platformdirs Changelog
 platformdirs 2.0.0
 ------------------
 
-- Name change as part of the friendly fork
+- **BREAKING** Name change as part of the friendly fork
+- **BREAKING** Remove support for end-of-life Pythons 2.6, 3.2, and 3.3
 - Add Python 3.7 support
-- Remove support for end-of-life Pythons 2.6, 3.2, and 3.3
 
 appdirs 1.4.4
 -------------


### PR DESCRIPTION
Fixes #11 

I didn't do these which I posted in the comment on the issue initially:
> - dropped pywin32 dependency

It appears that this wasn't a hard dependency of appdirs so I'm unsure this entry is needed.

> - added os.environ fallback for jython (not entirely sure whether appdirs 1.4.4 was affected as the logic for getting appdata seems to have changed since 1.4.4 as well and it might just be a bug that was only ever in master)

still not sure whether this was an issue in 1.4.4

I also added **BREAKING** prefix to aid people reading the changelog.
