### PR TITLE
Add links to docs an PyPI

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,10 @@ platformdirs's documentation
 This includes directories where to place cache files, user data, configuration,
 etc.
 
+The source code and issue tracker are both hosted at `GitHub`_.
+
+.. _GitHub: https://github.com/platformdirs/platformdirs
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ platformdirs's documentation
 This includes directories where to place cache files, user data, configuration,
 etc.
 
-The source code and issue tracker are both hosted at `GitHub`_.
+The source code and issue tracker are both hosted on `GitHub`_.
 
 .. _GitHub: https://github.com/platformdirs/platformdirs
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ keywords = application directory log cache user
 project_urls =
     Source=https://github.com/platformdirs/platformdirs
     Tracker=https://github.com/platformdirs/platformdirs/issues
+    Documentation=https://platformdirs.readthedocs.io/
 
 [options]
 packages = find:


### PR DESCRIPTION
A quick followup on #17.

The current docs don't link to the sourcecode or issue tracker in any way, and are a bit of a dead end in that sense.

Also link to the docs from PyPI.