### PR TITLE
Add API calls that return pathlib.Path instead of str objects 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 platformdirs Changelog
 ======================
 
+platformdirs 2.2.0
+------------------
+- [Issue 3] Add ``*_path`` API, returning :class:`pathlib.Path <pathlib.Path>` objects instead of :class:`str`
+  - by @papr
+
 platformdirs 2.1.0
 ------------------
 - Add ``readthedocs.org`` documentation via Sphinx

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ platformdirs 2.1.0
   :class:`PlatformDirsABC <platformdirs.api.PlatformDirsABC>` and it's implementations:
   :class:`Android <platformdirs.android.Android>`, :class:`MacOS <platformdirs.macos.MacOS>`,
   :class:`Unix <platformdirs.unix.Unix>` and :class:`Windows <platformdirs.windows.Windows>`
-- [Issue 3] Add ``*_path`` API, returning :class:`pathlib.Path <pathlib.Path>` objects instead of :class:`str`
+- Add ``*_path`` API, returning :class:`pathlib.Path <pathlib.Path>` objects instead of :class:`str`
   (``user_data_path``, ``user_config_path``, ``user_cache_path``, ``user_state_path``, ``user_log_path``,
   ``site_data_path``, ``site_config_path``) - by `@papr <https://github.com/papr/>`_
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,17 @@ platformdirs Changelog
 platformdirs 2.2.0
 ------------------
 - [Issue 3] Add ``*_path`` API, returning :class:`pathlib.Path <pathlib.Path>` objects instead of :class:`str`
-  - by @papr
+  - by `@papr <https://github.com/papr/>`_
+
+  * **NEW** :func:`user_data_path <platformdirs.user_data_path>`
+  * **NEW** :func:`user_config_path <platformdirs.user_config_path>`
+  * **NEW** :func:`user_cache_path <platformdirs.user_cache_path>`
+  * **NEW** :func:`user_state_path <platformdirs.user_state_path>`
+  * **NEW** :func:`user_log_path <platformdirs.user_log_path>`
+  * **NEW** :func:`site_data_path <platformdirs.site_data_path>` (**Note:** Always returns first item, even if the
+    ``multipath`` argument is set to ``True``)
+  * **NEW** :func:`site_config_path <platformdirs.site_config_path>`
+  * **NEW** Add the according properties to :class:`PlatformDirsABC <platformdirs.api.PlatformDirsABC>`
 
 platformdirs 2.1.0
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,21 +1,6 @@
 platformdirs Changelog
 ======================
 
-platformdirs 2.2.0
-------------------
-- [Issue 3] Add ``*_path`` API, returning :class:`pathlib.Path <pathlib.Path>` objects instead of :class:`str`
-  - by `@papr <https://github.com/papr/>`_
-
-  * **NEW** :func:`user_data_path <platformdirs.user_data_path>`
-  * **NEW** :func:`user_config_path <platformdirs.user_config_path>`
-  * **NEW** :func:`user_cache_path <platformdirs.user_cache_path>`
-  * **NEW** :func:`user_state_path <platformdirs.user_state_path>`
-  * **NEW** :func:`user_log_path <platformdirs.user_log_path>`
-  * **NEW** :func:`site_data_path <platformdirs.site_data_path>` (**Note:** Always returns first item, even if the
-    ``multipath`` argument is set to ``True``)
-  * **NEW** :func:`site_config_path <platformdirs.site_config_path>`
-  * **NEW** Add the according properties to :class:`PlatformDirsABC <platformdirs.api.PlatformDirsABC>`
-
 platformdirs 2.1.0
 ------------------
 - Add ``readthedocs.org`` documentation via Sphinx
@@ -27,6 +12,9 @@ platformdirs 2.1.0
   :class:`PlatformDirsABC <platformdirs.api.PlatformDirsABC>` and it's implementations:
   :class:`Android <platformdirs.android.Android>`, :class:`MacOS <platformdirs.macos.MacOS>`,
   :class:`Unix <platformdirs.unix.Unix>` and :class:`Windows <platformdirs.windows.Windows>`
+- [Issue 3] Add ``*_path`` API, returning :class:`pathlib.Path <pathlib.Path>` objects instead of :class:`str`
+  (``user_data_path``, ``user_config_path``, ``user_cache_path``, ``user_state_path``, ``user_log_path``,
+  ``site_data_path``, ``site_config_path``) - by `@papr <https://github.com/papr/>`_
 
 platformdirs 2.0.2
 ------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,26 +10,31 @@ User data directory
 -------------------
 
 .. autofunction:: platformdirs.user_data_dir
+.. autofunction:: platformdirs.user_data_path
 
 User config directory
 ---------------------
 
 .. autofunction:: platformdirs.user_config_dir
+.. autofunction:: platformdirs.user_config_path
 
 Cache directory
 -------------------
 
 .. autofunction:: platformdirs.user_cache_dir
+.. autofunction:: platformdirs.user_cache_path
 
 State directory
 -------------------
 
 .. autofunction:: platformdirs.user_state_dir
+.. autofunction:: platformdirs.user_state_path
 
 Logs directory
 -------------------
 
 .. autofunction:: platformdirs.user_log_dir
+.. autofunction:: platformdirs.user_log_path
 
 Shared directories
 ~~~~~~~~~~~~~~~~~~
@@ -40,11 +45,13 @@ Shared data directory
 ---------------------
 
 .. autofunction:: platformdirs.site_data_dir
+.. autofunction:: platformdirs.site_data_path
 
 Shared config directory
 -----------------------
 
 .. autofunction:: platformdirs.site_config_dir
+.. autofunction:: platformdirs.site_config_path
 
 Platforms
 ~~~~~~~~~

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -170,7 +170,7 @@ def site_data_path(
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
-    :param multipath: See `roaming <platformdirs.api.PlatformDirsABC.multipath>`.
+    :param multipath: See `multipath <platformdirs.api.PlatformDirsABC.multipath>`.
     :returns: data directory shared by users
     """
     return PlatformDirs(appname=appname, appauthor=appauthor, version=version, multipath=multipath).site_data_path

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -155,7 +155,7 @@ def user_data_path(
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.version>`.
-    :returns: data directory tied to the user
+    :returns: data path tied to the user
     """
     return PlatformDirs(appname=appname, appauthor=appauthor, version=version, roaming=roaming).user_data_path
 
@@ -171,7 +171,7 @@ def site_data_path(
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param multipath: See `multipath <platformdirs.api.PlatformDirsABC.multipath>`.
-    :returns: data directory shared by users
+    :returns: data path shared by users
     """
     return PlatformDirs(appname=appname, appauthor=appauthor, version=version, multipath=multipath).site_data_path
 
@@ -187,7 +187,7 @@ def user_config_path(
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.version>`.
-    :returns: config directory tied to the user
+    :returns: config path tied to the user
     """
     return PlatformDirs(appname=appname, appauthor=appauthor, version=version, roaming=roaming).user_config_path
 
@@ -203,7 +203,7 @@ def site_config_path(
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param multipath: See `roaming <platformdirs.api.PlatformDirsABC.multipath>`.
-    :returns: config directory shared by the users
+    :returns: config path shared by the users
     """
     return PlatformDirs(appname=appname, appauthor=appauthor, version=version, multipath=multipath).site_config_path
 
@@ -219,7 +219,7 @@ def user_cache_path(
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param opinion: See `roaming <platformdirs.api.PlatformDirsABC.opinion>`.
-    :returns: cache directory tied to the user
+    :returns: cache path tied to the user
     """
     return PlatformDirs(appname=appname, appauthor=appauthor, version=version, opinion=opinion).user_cache_path
 
@@ -235,7 +235,7 @@ def user_state_path(
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.version>`.
-    :returns: state directory tied to the user
+    :returns: state path tied to the user
     """
     return PlatformDirs(appname=appname, appauthor=appauthor, version=version, roaming=roaming).user_state_path
 
@@ -251,7 +251,7 @@ def user_log_path(
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param opinion: See `roaming <platformdirs.api.PlatformDirsABC.opinion>`.
-    :returns: log directory tied to the user
+    :returns: log path tied to the user
     """
     return PlatformDirs(appname=appname, appauthor=appauthor, version=version, opinion=opinion).user_log_path
 

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -5,6 +5,7 @@ usage.
 import importlib
 import os
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Type, Union
 
 if TYPE_CHECKING:
@@ -143,6 +144,118 @@ def user_log_dir(
     return PlatformDirs(appname=appname, appauthor=appauthor, version=version, opinion=opinion).user_log_dir
 
 
+def user_data_path(
+    appname: Optional[str] = None,
+    appauthor: Union[str, None, "Literal[False]"] = None,
+    version: Optional[str] = None,
+    roaming: bool = False,
+) -> Path:
+    """
+    :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.version>`.
+    :returns: data directory tied to the user
+    """
+    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, roaming=roaming).user_data_path
+
+
+def site_data_path(
+    appname: Optional[str] = None,
+    appauthor: Union[str, None, "Literal[False]"] = None,
+    version: Optional[str] = None,
+    multipath: bool = False,
+) -> Path:
+    """
+    :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param multipath: See `roaming <platformdirs.api.PlatformDirsABC.multipath>`.
+    :returns: data directory shared by users
+    """
+    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, multipath=multipath).site_data_path
+
+
+def user_config_path(
+    appname: Optional[str] = None,
+    appauthor: Union[str, None, "Literal[False]"] = None,
+    version: Optional[str] = None,
+    roaming: bool = False,
+) -> Path:
+    """
+    :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.version>`.
+    :returns: config directory tied to the user
+    """
+    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, roaming=roaming).user_config_path
+
+
+def site_config_path(
+    appname: Optional[str] = None,
+    appauthor: Union[str, None, "Literal[False]"] = None,
+    version: Optional[str] = None,
+    multipath: bool = False,
+) -> Path:
+    """
+    :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param multipath: See `roaming <platformdirs.api.PlatformDirsABC.multipath>`.
+    :returns: config directory shared by the users
+    """
+    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, multipath=multipath).site_config_path
+
+
+def user_cache_path(
+    appname: Optional[str] = None,
+    appauthor: Union[str, None, "Literal[False]"] = None,
+    version: Optional[str] = None,
+    opinion: bool = True,
+) -> Path:
+    """
+    :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param opinion: See `roaming <platformdirs.api.PlatformDirsABC.opinion>`.
+    :returns: cache directory tied to the user
+    """
+    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, opinion=opinion).user_cache_path
+
+
+def user_state_path(
+    appname: Optional[str] = None,
+    appauthor: Union[str, None, "Literal[False]"] = None,
+    version: Optional[str] = None,
+    roaming: bool = False,
+) -> Path:
+    """
+    :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.version>`.
+    :returns: state directory tied to the user
+    """
+    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, roaming=roaming).user_state_path
+
+
+def user_log_path(
+    appname: Optional[str] = None,
+    appauthor: Union[str, None, "Literal[False]"] = None,
+    version: Optional[str] = None,
+    opinion: bool = True,
+) -> Path:
+    """
+    :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param opinion: See `roaming <platformdirs.api.PlatformDirsABC.opinion>`.
+    :returns: log directory tied to the user
+    """
+    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, opinion=opinion).user_log_path
+
+
 __all__ = [
     "__version__",
     "__version_info__",
@@ -156,4 +269,11 @@ __all__ = [
     "user_log_dir",
     "site_data_dir",
     "site_config_dir",
+    "user_data_path",
+    "user_config_path",
+    "user_cache_path",
+    "user_state_path",
+    "user_log_path",
+    "site_data_path",
+    "site_config_path",
 ]

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Optional, Union
 
 if sys.version_info >= (3, 8):  # pragma: no branch
@@ -97,3 +98,38 @@ class PlatformDirsABC(ABC):
     @abstractmethod
     def user_log_dir(self) -> str:
         """:return: log directory tied to the user"""
+
+    @property
+    def user_data_path(self) -> Path:
+        """:return: data directory tied to the user"""
+        return Path(self.user_data_dir)
+
+    @property
+    def site_data_path(self) -> Path:
+        """:return: data directory shared by users"""
+        return Path(self.site_data_dir)
+
+    @property
+    def user_config_path(self) -> Path:
+        """:return: config directory tied to the user"""
+        return Path(self.user_config_dir)
+
+    @property
+    def site_config_path(self) -> Path:
+        """:return: config directory shared by the users"""
+        return Path(self.site_config_dir)
+
+    @property
+    def user_cache_path(self) -> Path:
+        """:return: cache directory tied to the user"""
+        return Path(self.user_cache_dir)
+
+    @property
+    def user_state_path(self) -> Path:
+        """:return: state directory tied to the user"""
+        return Path(self.user_state_dir)
+
+    @property
+    def user_log_path(self) -> Path:
+        """:return: log directory tied to the user"""
+        return Path(self.user_log_dir)

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -52,10 +52,7 @@ class PlatformDirsABC(ABC):
         self.multipath = multipath
         """
         An optional parameter only applicable to Unix/Linux which indicates that the entire list of data dirs should be
-        returned. By default, the first item would only be returned. This parameter does not affect the
-        :class:`pathlib.Path <pathlib.Path>`-returning methods, e.g. :meth:`platformdirs.site_data_path`. These always
-        return the first item. See `platformdirs/platformdirs#24
-        <https://github.com/platformdirs/platformdirs/issues/24>`_ for a discussion.
+        returned. By default, the first item would only be returned.
         """
         self.opinion = opinion  #: A flag to indicating to use opinionated values.
 
@@ -110,12 +107,7 @@ class PlatformDirsABC(ABC):
     @property
     def site_data_path(self) -> Path:
         """:return: data path shared by users"""
-        site_data_dir = self.site_data_dir
-        if self.multipath:
-            # If multipath is True, the first path is returned. See
-            # https://github.com/platformdirs/platformdirs/issues/24 for a discussion.
-            site_data_dir = site_data_dir.split(os.pathsep)[0]
-        return Path(site_data_dir)
+        return Path(self.site_data_dir)
 
     @property
     def user_config_path(self) -> Path:

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -104,12 +104,12 @@ class PlatformDirsABC(ABC):
 
     @property
     def user_data_path(self) -> Path:
-        """:return: data directory tied to the user"""
+        """:return: data path tied to the user"""
         return Path(self.user_data_dir)
 
     @property
     def site_data_path(self) -> Path:
-        """:return: data directory shared by users"""
+        """:return: data path shared by users"""
         site_data_dir = self.site_data_dir
         if self.multipath:
             # If multipath is True, the first path is returned. See
@@ -119,25 +119,25 @@ class PlatformDirsABC(ABC):
 
     @property
     def user_config_path(self) -> Path:
-        """:return: config directory tied to the user"""
+        """:return: config path tied to the user"""
         return Path(self.user_config_dir)
 
     @property
     def site_config_path(self) -> Path:
-        """:return: config directory shared by the users"""
+        """:return: config path shared by the users"""
         return Path(self.site_config_dir)
 
     @property
     def user_cache_path(self) -> Path:
-        """:return: cache directory tied to the user"""
+        """:return: cache path tied to the user"""
         return Path(self.user_cache_dir)
 
     @property
     def user_state_path(self) -> Path:
-        """:return: state directory tied to the user"""
+        """:return: state path tied to the user"""
         return Path(self.user_state_dir)
 
     @property
     def user_log_path(self) -> Path:
-        """:return: log directory tied to the user"""
+        """:return: log path tied to the user"""
         return Path(self.user_log_dir)

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -52,7 +52,10 @@ class PlatformDirsABC(ABC):
         self.multipath = multipath
         """
         An optional parameter only applicable to Unix/Linux which indicates that the entire list of data dirs should be
-        returned. By default, the first item would only be returned.
+        returned. By default, the first item would only be returned. This parameter does not affect the
+        :class:`pathlib.Path <pathlib.Path>`-returning methods, e.g. :meth:`platformdirs.site_data_path`. These always
+        return the first item. See `platformdirs/platformdirs#24
+        <https://github.com/platformdirs/platformdirs/issues/24>`_ for a discussion.
         """
         self.opinion = opinion  #: A flag to indicating to use opinionated values.
 
@@ -107,7 +110,12 @@ class PlatformDirsABC(ABC):
     @property
     def site_data_path(self) -> Path:
         """:return: data directory shared by users"""
-        return Path(self.site_data_dir)
+        site_data_dir = self.site_data_dir
+        if self.multipath:
+            # If multipath is True, the first path is returned. See
+            # https://github.com/platformdirs/platformdirs/issues/24 for a discussion.
+            site_data_dir = site_data_dir.split(os.pathsep)[0]
+        return Path(site_data_dir)
 
     @property
     def user_config_path(self) -> Path:

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -120,9 +120,6 @@ class Unix(PlatformDirsABC):
         return self._first_item_as_path_if_multipath(self.site_config_dir)
 
     def _first_item_as_path_if_multipath(self, directory: str) -> Path:
-        """
-        :return: first directory as path, even if ``multipath`` is set to ``True``
-        """
         if self.multipath:
             # If multipath is True, the first path is returned.
             directory = directory.split(os.pathsep)[0]

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from .api import PlatformDirsABC
 
@@ -66,7 +67,6 @@ class Unix(PlatformDirsABC):
         :return: config directories shared by users (if `multipath <platformdirs.api.PlatformDirsABC.multipath>`
          is enabled and ``XDG_DATA_DIR`` is set and a multi path the response is also a multi path separated by the OS
          path separator), e.g. ``/etc/xdg/$appname/$version``
-        :return:
         """
         # XDG default for $XDG_CONFIG_DIRS only first, if multipath is False
         if "XDG_CONFIG_DIRS" in os.environ:
@@ -108,6 +108,15 @@ class Unix(PlatformDirsABC):
         if self.opinion:
             path = os.path.join(path, "log")
         return path
+
+    @property
+    def site_data_path(self) -> Path:
+        """:return: data path shared by users. Only return first item, even if ``multipath`` is set to ``True``"""
+        site_data_dir = self.site_data_dir
+        if self.multipath:
+            # If multipath is True, the first path is returned.
+            site_data_dir = site_data_dir.split(os.pathsep)[0]
+        return Path(site_data_dir)
 
 
 __all__ = [

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -112,20 +112,21 @@ class Unix(PlatformDirsABC):
     @property
     def site_data_path(self) -> Path:
         """:return: data path shared by users. Only return first item, even if ``multipath`` is set to ``True``"""
-        site_data_dir = self.site_data_dir
-        if self.multipath:
-            # If multipath is True, the first path is returned.
-            site_data_dir = site_data_dir.split(os.pathsep)[0]
-        return Path(site_data_dir)
+        return self._first_item_as_path_if_multipath(self.site_data_dir)
 
     @property
     def site_config_path(self) -> Path:
         """:return: config path shared by the users. Only return first item, even if ``multipath`` is set to ``True``"""
-        site_config_dir = self.site_config_dir
+        return self._first_item_as_path_if_multipath(self.site_config_dir)
+
+    def _first_item_as_path_if_multipath(self, directory: str) -> Path:
+        """
+        :return: first directory as path, even if ``multipath`` is set to ``True``
+        """
         if self.multipath:
             # If multipath is True, the first path is returned.
-            site_config_dir = site_config_dir.split(os.pathsep)[0]
-        return Path(site_config_dir)
+            directory = directory.split(os.pathsep)[0]
+        return Path(directory)
 
 
 __all__ = [

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -118,6 +118,15 @@ class Unix(PlatformDirsABC):
             site_data_dir = site_data_dir.split(os.pathsep)[0]
         return Path(site_data_dir)
 
+    @property
+    def site_config_path(self) -> Path:
+        """:return: config path shared by the users. Only return first item, even if ``multipath`` is set to ``True``"""
+        site_config_dir = self.site_config_dir
+        if self.multipath:
+            # If multipath is True, the first path is returned.
+            site_config_dir = site_config_dir.split(os.pathsep)[0]
+        return Path(site_config_dir)
+
 
 __all__ = [
     "Unix",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,24 @@ PROPS = (
     "site_config_dir",
 )
 
+PROPS_PATH = (
+    "user_data_path",
+    "user_config_path",
+    "user_cache_path",
+    "user_state_path",
+    "user_log_path",
+    "site_data_path",
+    "site_config_path",
+)
+
 
 @pytest.fixture(params=PROPS)
 def func(request: SubRequest) -> str:
+    return cast(str, request.param)
+
+
+@pytest.fixture(params=PROPS_PATH)
+def func_path(request: SubRequest) -> str:
     return cast(str, request.param)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,25 +13,17 @@ PROPS = (
     "site_config_dir",
 )
 
-PROPS_PATH = (
-    "user_data_path",
-    "user_config_path",
-    "user_cache_path",
-    "user_state_path",
-    "user_log_path",
-    "site_data_path",
-    "site_config_path",
-)
-
 
 @pytest.fixture(params=PROPS)
 def func(request: SubRequest) -> str:
     return cast(str, request.param)
 
 
-@pytest.fixture(params=PROPS_PATH)
+@pytest.fixture(params=PROPS)
 def func_path(request: SubRequest) -> str:
-    return cast(str, request.param)
+    prop = cast(str, request.param)
+    prop = prop.replace("_dir", "_path")
+    return prop
 
 
 @pytest.fixture()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Optional
 
 import pytest
@@ -22,6 +23,18 @@ def test_property_result_is_str(func: str) -> None:
     dirs = platformdirs.PlatformDirs("MyApp", "MyCompany", version="1.0")
     result = getattr(dirs, func)
     assert isinstance(result, str)
+
+
+def test_method_result_is_path(func_path: str) -> None:
+    method = getattr(platformdirs, func_path)
+    result = method("MyApp", "MyCompany")
+    assert isinstance(result, Path)
+
+
+def test_property_result_is_path(func_path: str) -> None:
+    dirs = platformdirs.PlatformDirs("MyApp", "MyCompany", version="1.0")
+    result = getattr(dirs, func_path)
+    assert isinstance(result, Path)
 
 
 @pytest.mark.parametrize("root", ["A", "/system", None])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+import inspect
 from pathlib import Path
 from typing import Optional
 
@@ -35,6 +36,16 @@ def test_property_result_is_path(func_path: str) -> None:
     dirs = platformdirs.PlatformDirs("MyApp", "MyCompany", version="1.0")
     result = getattr(dirs, func_path)
     assert isinstance(result, Path)
+
+
+def test_function_interface_is_in_sync(func: str) -> None:
+    function_dir = getattr(platformdirs, func)
+    function_path = getattr(platformdirs, func.replace("_dir", "_path"))
+    assert inspect.isfunction(function_dir)
+    assert inspect.isfunction(function_path)
+    function_dir_signature = inspect.Signature.from_callable(function_dir)
+    function_path_signature = inspect.Signature.from_callable(function_path)
+    assert function_dir_signature.parameters == function_path_signature.parameters
 
 
 @pytest.mark.parametrize("root", ["A", "/system", None])

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -14,6 +14,7 @@ highbit
 HKEY
 impl
 intersphinx
+isfunction
 jnius
 kernel32
 lru

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -23,6 +23,7 @@ normpath
 ord
 param
 params
+pathlib
 pathsep
 platformdirs
 pyjnius


### PR DESCRIPTION
Implements #3 by wrapping the existing API in `pathlib.Path` calls and handles multipath-affected API as suggested in #24.