### PR TITLE
setup.cfg: set version using platformdirs.__version__

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 name = platformdirs
+version = attr: platformdirs.__version__
 description = A small Python module for determining appropriate platform-specific dirs, e.g. a "user data dir".
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
otherwise the generated PKG-INFO would contain a version of "0.0.0"

Signed-off-by: Kefu Chai <tchaikov@gmail.com>