### PR TITLE
Add `user_runtime_dir` for `$XDG_RUNTIME_DIR`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ On Android::
     >>> user_config_dir(appname)
     '/data/data/com.termux/shared_prefs/SuperApp'
     >>> user_runtime_dir(appname, appauthor)
-    'data/data/com.termux/tmp/SuperApp'
+    '/data/data/com.termux/cache/SuperApp/tmp'
 
 
 ``PlatformDirs`` for convenience

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,7 @@ This kind of thing is what the ``platformdirs`` module is for.
 - site data dir (``site_data_dir``)
 - site config dir (``site_config_dir``)
 - user log dir (``user_log_dir``)
+- user runtime dir (``user_runtime_dir``)
 
 And also:
 
@@ -65,6 +66,8 @@ On macOS:
     '/Users/trentm/Library/Caches/SuperApp'
     >>> user_log_dir(appname, appauthor)
     '/Users/trentm/Library/Logs/SuperApp'
+    >>> user_runtime_dir(appname, appauthor)
+    '/Users/trentm/Library/Caches/TemporaryItems/SuperApp'
 
 On Windows 7:
 
@@ -81,6 +84,8 @@ On Windows 7:
     'C:\\Users\\trentm\\AppData\\Local\\Acme\\SuperApp\\Cache'
     >>> user_log_dir(appname, appauthor)
     'C:\\Users\\trentm\\AppData\\Local\\Acme\\SuperApp\\Logs'
+    >>> user_runtime_dir(appname, appauthor)
+    'C:\\Users\\trentm\\AppData\\Local\\Temp\\Acme\\SuperApp'
 
 On Linux:
 
@@ -101,6 +106,8 @@ On Linux:
     '/home/trentm/.cache/SuperApp/log'
     >>> user_config_dir(appname)
     '/home/trentm/.config/SuperApp'
+    >>> user_runtime_dir(appname, appauthor)
+    '/run/user/{os.getuid()}/SuperApp'
     >>> site_config_dir(appname)
     '/etc/xdg/SuperApp'
     >>> os.environ['XDG_CONFIG_DIRS'] = '/etc:/usr/local/etc'
@@ -120,6 +127,8 @@ On Android::
     '/data/data/com.termux/cache/SuperApp/log'
     >>> user_config_dir(appname)
     '/data/data/com.termux/shared_prefs/SuperApp'
+    >>> user_runtime_dir(appname, appauthor)
+    'data/data/com.termux/tmp/SuperApp'
 
 
 ``PlatformDirs`` for convenience
@@ -137,6 +146,8 @@ On Android::
     '/Users/trentm/Library/Caches/SuperApp'
     >>> dirs.user_log_dir
     '/Users/trentm/Library/Logs/SuperApp'
+    >>> dirs.user_runtime_dir
+    '/Users/trentm/Library/Caches/TemporaryItems/SuperApp'
 
 Per-version isolation
 =====================
@@ -155,6 +166,8 @@ dirs::
     '/Users/trentm/Library/Caches/SuperApp/1.0'
     >>> dirs.user_log_dir
     '/Users/trentm/Library/Logs/SuperApp/1.0'
+    >>> dirs.user_runtime_dir
+    '/Users/trentm/Library/Caches/TemporaryItems/SuperApp/1.0'
 
 Be wary of using this for configuration files though; you'll need to handle
 migrating configuration files manually.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -36,6 +36,12 @@ Logs directory
 .. autofunction:: platformdirs.user_log_dir
 .. autofunction:: platformdirs.user_log_path
 
+Runtime directory
+-------------------
+
+.. autofunction:: platformdirs.user_runtime_dir
+.. autofunction:: platformdirs.user_runtime_path
+
 Shared directories
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -157,7 +157,7 @@ def user_runtime_dir(
     :param opinion: See `opinion <platformdirs.api.PlatformDirsABC.opinion>`.
     :returns: runtime directory tied to the user
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version).user_runtime_dir
+    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, opinion=opinion).user_runtime_dir
 
 
 def user_data_path(
@@ -285,7 +285,7 @@ def user_runtime_path(
     :param opinion: See `opinion <platformdirs.api.PlatformDirsABC.opinion>`.
     :returns: runtime path tied to the user
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version).user_runtime_path
+    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, opinion=opinion).user_runtime_path
 
 
 __all__ = [

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -144,6 +144,22 @@ def user_log_dir(
     return PlatformDirs(appname=appname, appauthor=appauthor, version=version, opinion=opinion).user_log_dir
 
 
+def user_runtime_dir(
+    appname: Optional[str] = None,
+    appauthor: Union[str, None, "Literal[False]"] = None,
+    version: Optional[str] = None,
+    opinion: bool = True,
+) -> str:
+    """
+    :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param opinion: See `opinion <platformdirs.api.PlatformDirsABC.opinion>`.
+    :returns: runtime directory tied to the user
+    """
+    return PlatformDirs(appname=appname, appauthor=appauthor, version=version).user_runtime_dir
+
+
 def user_data_path(
     appname: Optional[str] = None,
     appauthor: Union[str, None, "Literal[False]"] = None,
@@ -256,6 +272,22 @@ def user_log_path(
     return PlatformDirs(appname=appname, appauthor=appauthor, version=version, opinion=opinion).user_log_path
 
 
+def user_runtime_path(
+    appname: Optional[str] = None,
+    appauthor: Union[str, None, "Literal[False]"] = None,
+    version: Optional[str] = None,
+    opinion: bool = True,
+) -> Path:
+    """
+    :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param opinion: See `opinion <platformdirs.api.PlatformDirsABC.opinion>`.
+    :returns: runtime path tied to the user
+    """
+    return PlatformDirs(appname=appname, appauthor=appauthor, version=version).user_runtime_path
+
+
 __all__ = [
     "__version__",
     "__version_info__",
@@ -267,6 +299,7 @@ __all__ = [
     "user_cache_dir",
     "user_state_dir",
     "user_log_dir",
+    "user_runtime_dir",
     "site_data_dir",
     "site_config_dir",
     "user_data_path",
@@ -274,6 +307,7 @@ __all__ = [
     "user_cache_path",
     "user_state_path",
     "user_log_path",
+    "user_runtime_path",
     "site_data_path",
     "site_config_path",
 ]

--- a/src/platformdirs/__main__.py
+++ b/src/platformdirs/__main__.py
@@ -6,6 +6,7 @@ PROPS = (
     "user_cache_dir",
     "user_state_dir",
     "user_log_dir",
+    "user_runtime_dir",
     "site_data_dir",
     "site_config_dir",
 )

--- a/src/platformdirs/android.py
+++ b/src/platformdirs/android.py
@@ -56,6 +56,17 @@ class Android(PlatformDirsABC):
             path = os.path.join(path, "log")
         return path
 
+    @property
+    def user_runtime_dir(self) -> str:
+        """
+        :return: runtime directory tied to the user, same as `user_cache_dir` if not opinionated else ``tmp`` in it,
+          e.g. ``/data/user/<userid>/<packagename>/cache/<AppName>/tmp``
+        """
+        path = self.user_cache_dir
+        if self.opinion:
+            path = os.path.join(path, "tmp")
+        return path
+
 
 @lru_cache(maxsize=1)
 def _android_folder() -> str:

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -100,6 +100,11 @@ class PlatformDirsABC(ABC):
         """:return: log directory tied to the user"""
 
     @property
+    @abstractmethod
+    def user_runtime_dir(self) -> str:
+        """:return: runtime directory tied to the user"""
+
+    @property
     def user_data_path(self) -> Path:
         """:return: data path tied to the user"""
         return Path(self.user_data_dir)
@@ -133,3 +138,8 @@ class PlatformDirsABC(ABC):
     def user_log_path(self) -> Path:
         """:return: log path tied to the user"""
         return Path(self.user_log_dir)
+
+    @property
+    def user_runtime_path(self) -> Path:
+        """:return: runtime path tied to the user"""
+        return Path(self.user_runtime_dir)

--- a/src/platformdirs/macos.py
+++ b/src/platformdirs/macos.py
@@ -46,6 +46,11 @@ class MacOS(PlatformDirsABC):
         """:return: log directory tied to the user, e.g. ``~/Library/Logs/$appname/$version``"""
         return self._append_app_name_and_version(os.path.expanduser("~/Library/Logs"))
 
+    @property
+    def user_runtime_dir(self) -> str:
+        """:return: runtime directory tied to the user, e.g. ``~/Library/Caches/TemporaryItems/$appname/$version``"""
+        return self._append_app_name_and_version(os.path.expanduser("~/Library/Caches/TemporaryItems"))
+
 
 __all__ = [
     "MacOS",

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -1,7 +1,14 @@
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from .api import PlatformDirsABC
+
+if TYPE_CHECKING:
+    import sys
+
+    if sys.platform == "win32":
+        os.getuid = lambda: 1000
 
 
 class Unix(PlatformDirsABC):

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -104,6 +104,17 @@ class Unix(PlatformDirsABC):
         return path
 
     @property
+    def user_runtime_dir(self) -> str:
+        """
+        :return: runtime directory tied to the user, e.g. ``/run/user/$(id -u)/$appname/$version`` or
+         ``$XDG_RUNTIME_DIR/$appname/$version``
+        """
+        path = os.environ.get("XDG_RUNTIME_DIR", "")
+        if not path.strip():
+            path = f"/run/user/{os.getuid()}"
+        return self._append_app_name_and_version(path)
+
+    @property
     def site_data_path(self) -> Path:
         """:return: data path shared by users. Only return first item, even if ``multipath`` is set to ``True``"""
         return self._first_item_as_path_if_multipath(self.site_data_dir)

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -1,7 +1,10 @@
 import os
+import sys
 from pathlib import Path
 
 from .api import PlatformDirsABC
+
+assert sys.platform.startswith("linux")
 
 
 class Unix(PlatformDirsABC):

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -4,7 +4,12 @@ from pathlib import Path
 
 from .api import PlatformDirsABC
 
-assert sys.platform.startswith("linux")
+if sys.platform.startswith("linux"):  # pragma: no branch # no op check, only to please the type checker
+    from os import getuid
+else:
+
+    def getuid() -> int:
+        raise RuntimeError("should only be used on Linux")
 
 
 class Unix(PlatformDirsABC):
@@ -114,7 +119,7 @@ class Unix(PlatformDirsABC):
         """
         path = os.environ.get("XDG_RUNTIME_DIR", "")
         if not path.strip():
-            path = f"/run/user/{os.getuid()}"
+            path = f"/run/user/{getuid()}"
         return self._append_app_name_and_version(path)
 
     @property

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -1,14 +1,7 @@
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from .api import PlatformDirsABC
-
-if TYPE_CHECKING:
-    import sys
-
-    if sys.platform == "win32":
-        os.getuid = lambda: 1000
 
 
 class Unix(PlatformDirsABC):

--- a/src/platformdirs/windows.py
+++ b/src/platformdirs/windows.py
@@ -80,6 +80,15 @@ class Windows(PlatformDirsABC):
             path = os.path.join(path, "Logs")
         return path
 
+    @property
+    def user_runtime_dir(self) -> str:
+        """
+        :return: runtime directory tied to the user, e.g.
+         ``%USERPROFILE%\\AppData\\Local\\Temp\\$appauthor\\$appname``
+        """
+        path = os.path.normpath(os.path.join(get_win_folder("CSIDL_LOCAL_APPDATA"), "Temp"))
+        return self._append_parts(path)
+
 
 def get_win_folder_from_env_vars(csidl_name: str) -> str:
     """Get folder from environment variables."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ PROPS = (
     "user_cache_dir",
     "user_state_dir",
     "user_log_dir",
+    "user_runtime_dir",
     "site_data_dir",
     "site_config_dir",
 )

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -48,7 +48,7 @@ def test_android(mocker: MockerFixture, params: Dict[str, Any], func: str) -> No
         "user_cache_dir": f"/data/data/com.example/cache{suffix}",
         "user_state_dir": f"/data/data/com.example/files{suffix}",
         "user_log_dir": f"/data/data/com.example/cache{suffix}{'' if params.get('opinion', True) is False else '/log'}",
-        "user_runtime_dir": f"/data/data/com.example/cache{suffix}{'' if params.get('opinion', True) is False else '/tmp'}",
+        "user_runtime_dir": f"/data/data/com.example/cache{suffix}{'' if not params.get('opinion', True) else '/tmp'}",
     }
     expected = expected_map[func]
 

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -48,6 +48,7 @@ def test_android(mocker: MockerFixture, params: Dict[str, Any], func: str) -> No
         "user_cache_dir": f"/data/data/com.example/cache{suffix}",
         "user_state_dir": f"/data/data/com.example/files{suffix}",
         "user_log_dir": f"/data/data/com.example/cache{suffix}{'' if params.get('opinion', True) is False else '/log'}",
+        "user_runtime_dir": f"/data/data/com.example/cache{suffix}{'' if params.get('opinion', True) is False else '/tmp'}",
     }
     expected = expected_map[func]
 

--- a/tests/test_comp_with_appdirs.py
+++ b/tests/test_comp_with_appdirs.py
@@ -6,6 +6,8 @@ import pytest
 
 import platformdirs
 
+NEW_IN_PLATFORMDIRS = {"user_runtime_dir"}
+
 
 def test_has_backward_compatible_class() -> None:
     from platformdirs import AppDirs
@@ -29,6 +31,8 @@ def test_has_backward_compatible_class() -> None:
     ],
 )
 def test_compatibility(params: Dict[str, Any], func: str) -> None:
+    if func in NEW_IN_PLATFORMDIRS:
+        pytest.skip(f"`{func}` does not exist in `appdirs`")
     if sys.platform == "darwin":
         msg = {  # pragma: no cover
             "user_log_dir": "without appname produces NoneType error",

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -33,7 +33,7 @@ def dirs_instance() -> Unix:
 
 @pytest.fixture(autouse=True)
 def getuid(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setattr(os, "getuid", lambda: 1000)
+    monkeypatch.setattr(os, "getuid", lambda: 1000, raising=False)
 
 
 def test_xdg_variable_not_set(monkeypatch: MonkeyPatch, dirs_instance: Unix, func: str) -> None:

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -31,6 +31,11 @@ def dirs_instance() -> Unix:
     return Unix(multipath=True, opinion=False)
 
 
+@pytest.fixture(autouse=True)
+def getuid(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(os, "getuid", lambda: 1000)
+
+
 def test_xdg_variable_not_set(monkeypatch: MonkeyPatch, dirs_instance: Unix, func: str) -> None:
     xdg_variable = _func_to_path(func)
     monkeypatch.delenv(xdg_variable.name, raising=False)

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -32,7 +32,7 @@ def dirs_instance() -> Unix:
 
 
 @pytest.fixture(autouse=True)
-def getuid(monkeypatch: MonkeyPatch) -> None:
+def _getuid(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(os, "getuid", lambda: 1000, raising=False)
 
 

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -21,6 +21,7 @@ def _func_to_path(func: str) -> XDGVariable:
         "user_cache_dir": XDGVariable("XDG_CACHE_HOME", "~/.cache"),
         "user_state_dir": XDGVariable("XDG_STATE_HOME", "~/.local/state"),
         "user_log_dir": XDGVariable("XDG_CACHE_HOME", "~/.cache"),
+        "user_runtime_dir": XDGVariable("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}"),
     }
     return mapping[func]
 

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -1,8 +1,11 @@
+import importlib
 import os
+import sys
 import typing
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
+from pytest_mock import MockerFixture
 
 from platformdirs.unix import Unix
 
@@ -21,7 +24,7 @@ def _func_to_path(func: str) -> XDGVariable:
         "user_cache_dir": XDGVariable("XDG_CACHE_HOME", "~/.cache"),
         "user_state_dir": XDGVariable("XDG_STATE_HOME", "~/.local/state"),
         "user_log_dir": XDGVariable("XDG_CACHE_HOME", "~/.cache"),
-        "user_runtime_dir": XDGVariable("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}"),
+        "user_runtime_dir": XDGVariable("XDG_RUNTIME_DIR", "/run/user/1234"),
     }
     return mapping[func]
 
@@ -31,11 +34,12 @@ def dirs_instance() -> Unix:
     return Unix(multipath=True, opinion=False)
 
 
-@pytest.fixture(autouse=True)
-def _getuid(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setattr(os, "getuid", lambda: 1000, raising=False)
+@pytest.fixture()
+def _getuid(mocker: MockerFixture) -> None:
+    mocker.patch("platformdirs.unix.getuid", return_value=1234)
 
 
+@pytest.mark.usefixtures("_getuid")
 def test_xdg_variable_not_set(monkeypatch: MonkeyPatch, dirs_instance: Unix, func: str) -> None:
     xdg_variable = _func_to_path(func)
     monkeypatch.delenv(xdg_variable.name, raising=False)
@@ -43,6 +47,7 @@ def test_xdg_variable_not_set(monkeypatch: MonkeyPatch, dirs_instance: Unix, fun
     assert result == os.path.expanduser(xdg_variable.default_value)
 
 
+@pytest.mark.usefixtures("_getuid")
 def test_xdg_variable_empty_value(monkeypatch: MonkeyPatch, dirs_instance: Unix, func: str) -> None:
     xdg_variable = _func_to_path(func)
     monkeypatch.setenv(xdg_variable.name, "")
@@ -50,8 +55,23 @@ def test_xdg_variable_empty_value(monkeypatch: MonkeyPatch, dirs_instance: Unix,
     assert result == os.path.expanduser(xdg_variable.default_value)
 
 
+@pytest.mark.usefixtures("_getuid")
 def test_xdg_variable_custom_value(monkeypatch: MonkeyPatch, dirs_instance: Unix, func: str) -> None:
     xdg_variable = _func_to_path(func)
     monkeypatch.setenv(xdg_variable.name, "/tmp/custom-dir")
     result = getattr(dirs_instance, func)
     assert result == "/tmp/custom-dir"
+
+
+def test_platform_non_linux(monkeypatch: MonkeyPatch) -> None:
+    from platformdirs import unix
+
+    try:
+        with monkeypatch.context() as context:
+            context.setattr(sys, "platform", "magic")
+            monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+            importlib.reload(unix)
+        with pytest.raises(RuntimeError, match="should only be used on Linux"):
+            unix.Unix().user_runtime_dir
+    finally:
+        importlib.reload(unix)

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -3,17 +3,16 @@ appdirs
 appname
 autoclass
 autodoc
-autouse
 buf
 buf2
 const
 csidl
 delenv
-Dirs
+dirs
 func
 getuid
 highbit
-HKEY
+hkey
 intersphinx
 isfunction
 jnius
@@ -33,5 +32,6 @@ setenv
 shell32
 typehints
 unittest
+usefixtures
 winreg
-XDG
+xdg

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -3,6 +3,7 @@ appdirs
 appname
 autoclass
 autodoc
+autouse
 buf
 buf2
 const
@@ -10,6 +11,7 @@ csidl
 delenv
 Dirs
 func
+getuid
 highbit
 HKEY
 intersphinx

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -26,6 +26,7 @@ pathlib
 pathsep
 platformdirs
 pyjnius
+runtime
 setenv
 shell32
 typehints


### PR DESCRIPTION
Closes #36.

### Unix
I chose to default to `/run/user/{os.getuid()}` because that's what `$XDG_RUNTIME_DIR` was by default on my Ubuntu machine, but I'm not sure how standard that is on other unixes. Something like `/tmp/$USER` could work too.

### Mac
The [Mac reference](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html) in the `MacOS` docstring doesn't say anything about temporary files, but I found some [mentions](https://osxdaily.com/2018/08/17/where-temp-folder-mac-access/) of `~/Library/Caches/TemporaryItems` so I used that.

### Windows
[These](https://www.askvg.com/where-does-windows-store-temporary-files-and-how-to-change-temp-folder-location/) [links](https://www.thewindowsclub.com/temporary-files-folder-location-windows) say that Windows puts temporary files in `%USERPROFILE%\AppData\Local\Temp` so that's what I used.

### Android
I couldn't find anything saying where temporary files usually go on Android so I just followed the lead of `user_log_dir` and used `user_cache_dir` with an optional `tmp` suffix if `self.opinion` is set. I don't think this satisfies the part of the [XDG spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) that says:
> The lifetime of the directory MUST be bound to the user being logged in.

But maybe that's fine since `platformdirs` isn't claiming to exactly follow the spec completely in a completely platform-agnostic way.

Let me know if you want me to change any of these locations or add comments explaining the choices.