### PR TITLE
Support for Termux subsystem

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,9 @@
 platformdirs Changelog
 ======================
 
-platformdirs 2.4.2
+platformdirs 2.5.0
 ------------------
-- Fix OSError when platformdirs is runned from subsystem in Termux
+- Add support for Termux subsystems
 
 platformdirs 2.4.1
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 platformdirs Changelog
 ======================
 
+platformdirs 2.4.2
+------------------
+- Fix OSError when platformdirs is runned from subsystem in Termux
+
 platformdirs 2.4.1
 ------------------
 - Drop python 3.6 support

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -18,14 +18,19 @@ from .version import __version__, __version_info__
 
 
 def _set_platform_dir_class() -> type[PlatformDirsABC]:
-    if os.getenv("ANDROID_DATA") == "/data" and os.getenv("ANDROID_ROOT") == "/system":
-        module, name = "platformdirs.android", "Android"
-    elif sys.platform == "win32":
+    if sys.platform == "win32":
         module, name = "platformdirs.windows", "Windows"
     elif sys.platform == "darwin":
         module, name = "platformdirs.macos", "MacOS"
     else:
         module, name = "platformdirs.unix", "Unix"
+
+    if os.getenv("ANDROID_DATA") == "/data" and os.getenv("ANDROID_ROOT") == "/system":
+        from platformdirs.android import _android_folder
+
+        if _android_folder() is not None:
+            module, name = "platformdirs.android", "Android"
+
     result: type[PlatformDirsABC] = getattr(importlib.import_module(module), name)
     return result
 

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -28,7 +28,7 @@ def _set_platform_dir_class() -> type[PlatformDirsABC]:
     if os.getenv("ANDROID_DATA") == "/data" and os.getenv("ANDROID_ROOT") == "/system":
         from platformdirs.android import _android_folder
 
-        if _android_folder():
+        if _android_folder() is not None:
             module, name = "platformdirs.android", "Android"
 
     result: type[PlatformDirsABC] = getattr(importlib.import_module(module), name)

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -28,7 +28,7 @@ def _set_platform_dir_class() -> type[PlatformDirsABC]:
     if os.getenv("ANDROID_DATA") == "/data" and os.getenv("ANDROID_ROOT") == "/system":
         from platformdirs.android import _android_folder
 
-        if _android_folder() is not None:
+        if _android_folder():
             module, name = "platformdirs.android", "Android"
 
     result: type[PlatformDirsABC] = getattr(importlib.import_module(module), name)

--- a/src/platformdirs/android.py
+++ b/src/platformdirs/android.py
@@ -18,7 +18,7 @@ class Android(PlatformDirsABC):
     @property
     def user_data_dir(self) -> str:
         """:return: data directory tied to the user, e.g. ``/data/user/<userid>/<packagename>/files/<AppName>``"""
-        return self._append_app_name_and_version(_android_folder(), "files")
+        return self._append_app_name_and_version(_android_folder() or "", "files")
 
     @property
     def site_data_dir(self) -> str:
@@ -30,7 +30,7 @@ class Android(PlatformDirsABC):
         """
         :return: config directory tied to the user, e.g. ``/data/user/<userid>/<packagename>/shared_prefs/<AppName>``
         """
-        return self._append_app_name_and_version(_android_folder(), "shared_prefs")
+        return self._append_app_name_and_version(_android_folder() or "", "shared_prefs")
 
     @property
     def site_config_dir(self) -> str:
@@ -40,7 +40,7 @@ class Android(PlatformDirsABC):
     @property
     def user_cache_dir(self) -> str:
         """:return: cache directory tied to the user, e.g. e.g. ``/data/user/<userid>/<packagename>/cache/<AppName>``"""
-        return self._append_app_name_and_version(_android_folder(), "cache")
+        return self._append_app_name_and_version(_android_folder() or "", "cache")
 
     @property
     def user_state_dir(self) -> str:
@@ -78,14 +78,14 @@ class Android(PlatformDirsABC):
 
 
 @lru_cache(maxsize=1)
-def _android_folder() -> str:
-    """:return: base folder for the Android OS. If such cannot be found, an empty string is returned"""
+def _android_folder() -> str | None:
+    """:return: base folder for the Android OS. If such cannot be found, `None` is returned"""
     try:
         # First try to get path to android app via pyjnius
         from jnius import autoclass
 
         Context = autoclass("android.content.Context")  # noqa: N806
-        result: str = Context.getFilesDir().getParentFile().getAbsolutePath()
+        result: str | None = Context.getFilesDir().getParentFile().getAbsolutePath()
     except Exception:
         # if fails find an android folder looking path on the sys.path
         pattern = re.compile(r"/data/(data|user/\d+)/(.+)/files")
@@ -94,7 +94,7 @@ def _android_folder() -> str:
                 result = path.split("/files")[0]
                 break
         else:
-            result = ""
+            result = None
     return result
 
 

--- a/src/platformdirs/android.py
+++ b/src/platformdirs/android.py
@@ -78,8 +78,8 @@ class Android(PlatformDirsABC):
 
 
 @lru_cache(maxsize=1)
-def _android_folder() -> str | None:
-    """:return: base folder for the Android OS"""
+def _android_folder() -> str:
+    """:return: base folder for the Android OS. If such cannot be found, an empty string is returned"""
     try:
         # First try to get path to android app via pyjnius
         from jnius import autoclass
@@ -94,7 +94,7 @@ def _android_folder() -> str | None:
                 result = path.split("/files")[0]
                 break
         else:
-            result = None
+            result = ""
     return result
 
 

--- a/src/platformdirs/android.py
+++ b/src/platformdirs/android.py
@@ -79,7 +79,7 @@ class Android(PlatformDirsABC):
 
 @lru_cache(maxsize=1)
 def _android_folder() -> str | None:
-    """:return: base folder for the Android OS. If such cannot be found, `None` is returned"""
+    """:return: base folder for the Android OS or None if cannot be found"""
     try:
         # First try to get path to android app via pyjnius
         from jnius import autoclass

--- a/src/platformdirs/android.py
+++ b/src/platformdirs/android.py
@@ -4,6 +4,7 @@ import os
 import re
 import sys
 from functools import lru_cache
+from typing import cast
 
 from .api import PlatformDirsABC
 
@@ -18,7 +19,7 @@ class Android(PlatformDirsABC):
     @property
     def user_data_dir(self) -> str:
         """:return: data directory tied to the user, e.g. ``/data/user/<userid>/<packagename>/files/<AppName>``"""
-        return self._append_app_name_and_version(_android_folder() or "", "files")
+        return self._append_app_name_and_version(cast(str, _android_folder()), "files")
 
     @property
     def site_data_dir(self) -> str:
@@ -30,7 +31,7 @@ class Android(PlatformDirsABC):
         """
         :return: config directory tied to the user, e.g. ``/data/user/<userid>/<packagename>/shared_prefs/<AppName>``
         """
-        return self._append_app_name_and_version(_android_folder() or "", "shared_prefs")
+        return self._append_app_name_and_version(cast(str, _android_folder()), "shared_prefs")
 
     @property
     def site_config_dir(self) -> str:
@@ -40,7 +41,7 @@ class Android(PlatformDirsABC):
     @property
     def user_cache_dir(self) -> str:
         """:return: cache directory tied to the user, e.g. e.g. ``/data/user/<userid>/<packagename>/cache/<AppName>``"""
-        return self._append_app_name_and_version(_android_folder() or "", "cache")
+        return self._append_app_name_and_version(cast(str, _android_folder()), "cache")
 
     @property
     def user_state_dir(self) -> str:

--- a/src/platformdirs/android.py
+++ b/src/platformdirs/android.py
@@ -78,7 +78,7 @@ class Android(PlatformDirsABC):
 
 
 @lru_cache(maxsize=1)
-def _android_folder() -> str:
+def _android_folder() -> str | None:
     """:return: base folder for the Android OS"""
     try:
         # First try to get path to android app via pyjnius
@@ -94,7 +94,7 @@ def _android_folder() -> str:
                 result = path.split("/files")[0]
                 break
         else:
-            raise OSError("Cannot find path to android app folder")
+            result = None
     return result
 
 

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -110,4 +110,4 @@ def test_android_folder_not_found(mocker: MockerFixture, monkeypatch: MonkeyPatc
 
     _android_folder.cache_clear()
     monkeypatch.setattr(sys, "path", [])
-    assert _android_folder() is None
+    assert not _android_folder()

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -110,4 +110,4 @@ def test_android_folder_not_found(mocker: MockerFixture, monkeypatch: MonkeyPatc
 
     _android_folder.cache_clear()
     monkeypatch.setattr(sys, "path", [])
-    assert not _android_folder()
+    assert _android_folder() is None

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -110,5 +110,4 @@ def test_android_folder_not_found(mocker: MockerFixture, monkeypatch: MonkeyPatc
 
     _android_folder.cache_clear()
     monkeypatch.setattr(sys, "path", [])
-    with pytest.raises(OSError, match="Cannot find path to android app folder"):
-        _android_folder()
+    assert _android_folder() is None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -65,7 +65,7 @@ def test_android_active(monkeypatch: MonkeyPatch, root: str | None, data: str | 
     _android_folder.cache_clear()
     monkeypatch.setattr(sys, "path", ["/A", "/B", path])
 
-    expected = root == "/system" and data == "/data" and _android_folder()
+    expected = root == "/system" and data == "/data" and _android_folder() is not None
     if expected:
         assert platformdirs._set_platform_dir_class() is Android
     else:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import sys
 from pathlib import Path
 
 import pytest
@@ -51,14 +52,20 @@ def test_function_interface_is_in_sync(func: str) -> None:
 
 @pytest.mark.parametrize("root", ["A", "/system", None])
 @pytest.mark.parametrize("data", ["D", "/data", None])
-def test_android_active(monkeypatch: MonkeyPatch, root: str | None, data: str | None) -> None:
+@pytest.mark.parametrize("path", ["/data/data/a/files", "/C"])
+def test_android_active(monkeypatch: MonkeyPatch, root: str | None, data: str | None, path: str) -> None:
     for env_var, value in {"ANDROID_DATA": data, "ANDROID_ROOT": root}.items():
         if value is None:
             monkeypatch.delenv(env_var, raising=False)
         else:
             monkeypatch.setenv(env_var, value)
 
-    expected = root == "/system" and data == "/data"
+    from platformdirs.android import _android_folder
+
+    _android_folder.cache_clear()
+    monkeypatch.setattr(sys, "path", ["/A", "/B", path])
+
+    expected = root == "/system" and data == "/data" and _android_folder()
     if expected:
         assert platformdirs._set_platform_dir_class() is Android
     else:


### PR DESCRIPTION
Fix of #62 

Platformdirs on Termux under Arch Linux subsystem:
```sh
-- platformdirs 2.4.2.dev4+gbd70a11 --
-- app dirs (with optional 'version')
user_data_dir: /root/.local/share/MyApp/1.0
user_config_dir: /root/.config/MyApp/1.0
user_cache_dir: /root/.cache/MyApp/1.0
user_state_dir: /root/.local/state/MyApp/1.0
user_log_dir: /root/.cache/MyApp/1.0/log
user_documents_dir: /root/Documents
user_runtime_dir: /run/user/0/MyApp/1.0
site_data_dir: /usr/local/share/MyApp/1.0
site_config_dir: /etc/xdg/MyApp/1.0

-- app dirs (without optional 'version')
user_data_dir: /root/.local/share/MyApp
user_config_dir: /root/.config/MyApp
user_cache_dir: /root/.cache/MyApp
user_state_dir: /root/.local/state/MyApp
user_log_dir: /root/.cache/MyApp/log
user_documents_dir: /root/Documents
user_runtime_dir: /run/user/0/MyApp
site_data_dir: /usr/local/share/MyApp
site_config_dir: /etc/xdg/MyApp

-- app dirs (without optional 'appauthor')
user_data_dir: /root/.local/share/MyApp
user_config_dir: /root/.config/MyApp
user_cache_dir: /root/.cache/MyApp
user_state_dir: /root/.local/state/MyApp
user_log_dir: /root/.cache/MyApp/log
user_documents_dir: /root/Documents
user_runtime_dir: /run/user/0/MyApp
site_data_dir: /usr/local/share/MyApp
site_config_dir: /etc/xdg/MyApp

-- app dirs (with disabled 'appauthor')
user_data_dir: /root/.local/share/MyApp
user_config_dir: /root/.config/MyApp
user_cache_dir: /root/.cache/MyApp
user_state_dir: /root/.local/state/MyApp
user_log_dir: /root/.cache/MyApp/log
user_documents_dir: /root/Documents
user_runtime_dir: /run/user/0/MyApp
site_data_dir: /usr/local/share/MyApp
site_config_dir: /etc/xdg/MyApp
```

Platformdirs on Termux:
```
-- platformdirs 2.4.2.dev4+gbd70a11 --
-- app dirs (with optional 'version')
user_data_dir: /data/data/com.termux/files/MyApp/1.0
user_config_dir: /data/data/com.termux/shared_prefs/MyApp/1.0
user_cache_dir: /data/data/com.termux/cache/MyApp/1.0
user_state_dir: /data/data/com.termux/files/MyApp/1.0
user_log_dir: /data/data/com.termux/cache/MyApp/1.0/log
user_documents_dir: /storage/emulated/0/Documents
user_runtime_dir: /data/data/com.termux/cache/MyApp/1.0/tmp
site_data_dir: /data/data/com.termux/files/MyApp/1.0
site_config_dir: /data/data/com.termux/shared_prefs/MyApp/1.0

-- app dirs (without optional 'version')
user_data_dir: /data/data/com.termux/files/MyApp
user_config_dir: /data/data/com.termux/shared_prefs/MyApp
user_cache_dir: /data/data/com.termux/cache/MyApp
user_state_dir: /data/data/com.termux/files/MyApp
user_log_dir: /data/data/com.termux/cache/MyApp/log
user_documents_dir: /storage/emulated/0/Documents
user_runtime_dir: /data/data/com.termux/cache/MyApp/tmp
site_data_dir: /data/data/com.termux/files/MyApp
site_config_dir: /data/data/com.termux/shared_prefs/MyApp

-- app dirs (without optional 'appauthor')
user_data_dir: /data/data/com.termux/files/MyApp
user_config_dir: /data/data/com.termux/shared_prefs/MyApp
user_cache_dir: /data/data/com.termux/cache/MyApp
user_state_dir: /data/data/com.termux/files/MyApp
user_log_dir: /data/data/com.termux/cache/MyApp/log
user_documents_dir: /storage/emulated/0/Documents
user_runtime_dir: /data/data/com.termux/cache/MyApp/tmp
site_data_dir: /data/data/com.termux/files/MyApp
site_config_dir: /data/data/com.termux/shared_prefs/MyApp

-- app dirs (with disabled 'appauthor')
user_data_dir: /data/data/com.termux/files/MyApp
user_config_dir: /data/data/com.termux/shared_prefs/MyApp
user_cache_dir: /data/data/com.termux/cache/MyApp
user_state_dir: /data/data/com.termux/files/MyApp
user_log_dir: /data/data/com.termux/cache/MyApp/log
user_documents_dir: /storage/emulated/0/Documents
user_runtime_dir: /data/data/com.termux/cache/MyApp/tmp
site_data_dir: /data/data/com.termux/files/MyApp
site_config_dir: /data/data/com.termux/shared_prefs/MyApp
```