### PR TITLE
Treat android shells as unix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,17 +127,24 @@ On Android::
     >>> appname = "SuperApp"
     >>> appauthor = "Acme"
     >>> user_data_dir(appname, appauthor)
-    '/data/data/com.termux/files/SuperApp'
+    '/data/data/com.myApp/files/SuperApp'
     >>> user_cache_dir(appname, appauthor)
-    '/data/data/com.termux/cache/SuperApp'
+    '/data/data/com.myApp/cache/SuperApp'
     >>> user_log_dir(appname, appauthor)
-    '/data/data/com.termux/cache/SuperApp/log'
+    '/data/data/com.myApp/cache/SuperApp/log'
     >>> user_config_dir(appname)
-    '/data/data/com.termux/shared_prefs/SuperApp'
+    '/data/data/com.myApp/shared_prefs/SuperApp'
     >>> user_documents_dir()
     '/storage/emulated/0/Documents'
     >>> user_runtime_dir(appname, appauthor)
-    '/data/data/com.termux/cache/SuperApp/tmp'
+    '/data/data/com.myApp/cache/SuperApp/tmp'
+
+Note: Some android apps like Termux and Pydroid are used as shells. These
+apps are used by the end user to emulate Linux environment. Presence of
+``SHELL`` environment variable is used by Platformdirs to differentiate
+between general android apps and android apps used as shells. Shell android
+apps also support ``XDG_*`` environment variables.
+
 
 ``PlatformDirs`` for convenience
 ================================

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -25,11 +25,11 @@ def _set_platform_dir_class() -> type[PlatformDirsABC]:
         from platformdirs.unix import Unix as Result
 
     if os.getenv("ANDROID_DATA") == "/data" and os.getenv("ANDROID_ROOT") == "/system":
-        from platformdirs.android import _android_folder
 
         if os.getenv("SHELL") is not None:
             return Result
 
+        from platformdirs.android import _android_folder
         if _android_folder() is not None:
             from platformdirs.android import Android
 

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -30,6 +30,7 @@ def _set_platform_dir_class() -> type[PlatformDirsABC]:
             return Result
 
         from platformdirs.android import _android_folder
+
         if _android_folder() is not None:
             from platformdirs.android import Android
 

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -27,6 +27,9 @@ def _set_platform_dir_class() -> type[PlatformDirsABC]:
     if os.getenv("ANDROID_DATA") == "/data" and os.getenv("ANDROID_ROOT") == "/system":
         from platformdirs.android import _android_folder
 
+        if os.getenv("SHELL") is not None:
+            return Result
+
         if _android_folder() is not None:
             from platformdirs.android import Android
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -53,8 +53,11 @@ def test_function_interface_is_in_sync(func: str) -> None:
 @pytest.mark.parametrize("root", ["A", "/system", None])
 @pytest.mark.parametrize("data", ["D", "/data", None])
 @pytest.mark.parametrize("path", ["/data/data/a/files", "/C"])
-def test_android_active(monkeypatch: MonkeyPatch, root: str | None, data: str | None, path: str) -> None:
-    for env_var, value in {"ANDROID_DATA": data, "ANDROID_ROOT": root}.items():
+@pytest.mark.parametrize("shell", ["/data/data/com.app/files/usr/bin/sh", "/usr/bin/sh", None])
+def test_android_active(
+    monkeypatch: MonkeyPatch, root: str | None, data: str | None, path: str, shell: str | None
+) -> None:
+    for env_var, value in {"ANDROID_DATA": data, "ANDROID_ROOT": root, "SHELL": shell}.items():
         if value is None:
             monkeypatch.delenv(env_var, raising=False)
         else:
@@ -65,7 +68,7 @@ def test_android_active(monkeypatch: MonkeyPatch, root: str | None, data: str | 
     _android_folder.cache_clear()
     monkeypatch.setattr(sys, "path", ["/A", "/B", path])
 
-    expected = root == "/system" and data == "/data" and _android_folder() is not None
+    expected = root == "/system" and data == "/data" and shell is None and _android_folder() is not None
     if expected:
         assert platformdirs._set_platform_dir_class() is Android
     else:


### PR DESCRIPTION
Fixes #70  Treats all android shells as unix

Doesn't support custom prefixed development environments as it isn't standardized in any  specific android application shell. Custom prefixes if implemented, needs per application check, for each application.  I've decided against implementing prefixes as it it's better handled directly by `XDG_*` environment variables.