### PR TITLE
unix: Use user_state_dir as base for user_log_dir

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 platformdirs Changelog
 ======================
 
+platformdirs 2.6.0
+------------------
+- Unix: Change ``user_log_dir`` to be under ``user_state_dir`` in line with the latest XDG specification
+
 platformdirs 2.5.1
 ------------------
 - Add native support for nuitka

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -107,9 +107,9 @@ class Unix(PlatformDirsABC):
     @property
     def user_log_dir(self) -> str:
         """
-        :return: log directory tied to the user, same as `user_data_dir` if not opinionated else ``log`` in it
+        :return: log directory tied to the user, same as `user_state_dir` if not opinionated else ``log`` in it
         """
-        path = self.user_cache_dir
+        path = self.user_state_dir
         if self.opinion:
             path = os.path.join(path, "log")
         return path

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -59,7 +59,7 @@ def _func_to_path(func: str) -> XDGVariable | None:
         "site_config_dir": XDGVariable("XDG_CONFIG_DIRS", "/etc/xdg"),
         "user_cache_dir": XDGVariable("XDG_CACHE_HOME", "~/.cache"),
         "user_state_dir": XDGVariable("XDG_STATE_HOME", "~/.local/state"),
-        "user_log_dir": XDGVariable("XDG_CACHE_HOME", "~/.cache"),
+        "user_log_dir": XDGVariable("XDG_STATE_HOME", "~/.local/state"),
         "user_runtime_dir": XDGVariable("XDG_RUNTIME_DIR", "/run/user/1234"),
     }
     return mapping.get(func)


### PR DESCRIPTION
This is recommended by the latest XDG specification.