### PR TITLE
Update Black version to 22.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         args: [ --safe ]
@@ -29,7 +29,7 @@ repos:
     rev: v1.12.1
     hooks:
       - id: blacken-docs
-        additional_dependencies: [ black==22.1.0 ]
+        additional_dependencies: [ black==22.3.0 ]
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0
     hooks:


### PR DESCRIPTION
lint check is currently failing due to black 22.1.0's incompatibility with click 8.1.