### PR TITLE
Docs: platformdirs is a package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ On Linux (and other Unices), according to the `XDG Basedir Spec`_, it should be:
 ``platformdirs`` to the rescue
 ==============================
 
-This kind of thing is what the ``platformdirs`` module is for.
+This kind of thing is what the ``platformdirs`` package is for.
 ``platformdirs`` will help you choose an appropriate:
 
 - user data dir (``user_data_dir``)
@@ -45,7 +45,6 @@ This kind of thing is what the ``platformdirs`` module is for.
 
 And also:
 
-- Is a single module so other Python packages can vendor their own private copy.
 - Is slightly opinionated on the directory names used. Look for "OPINION" in
   documentation and code for when an opinion is being applied.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["hatchling>=0.22.0", "hatch-vcs"]
 
 [project]
 name = "platformdirs"
-description = 'A small Python module for determining appropriate platform-specific dirs, e.g. a "user data dir".'
+description = 'A small Python package for determining appropriate platform-specific dirs, e.g. a "user data dir".'
 readme = "README.rst"
 license = "MIT"
 maintainers = [


### PR DESCRIPTION
It looks like `platformdirs` is no longer a single module. I have updated the README and project description to reflect this change.