### PR TITLE
#122: Add typing-extensions as dependency when python_version < 3.8

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 platformdirs Changelog
 ======================
 
+platformdirs 2.6.2 (2022-12-28)
+-------------------------------
+- Fix missing ``typing-extensions`` dependency.
+
 platformdirs 2.6.1 (2022-12-28)
 -------------------------------
 - Add detection of ``$PREFIX`` for android.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,7 @@ urls.Homepage = "https://github.com/platformdirs/platformdirs"
 urls.Source = "https://github.com/platformdirs/platformdirs"
 urls.Tracker = "https://github.com/platformdirs/platformdirs/issues"
 requires-python = ">=3.7"
-dependencies = [
-  "typing-extensions; python_version < '3.8'"
-]
+dependencies = ['typing-extensions>=4.4; python_version < "3.8"']
 optional-dependencies.test = [
   "appdirs==1.4.4",
   "covdefaults>=2.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ urls.Homepage = "https://github.com/platformdirs/platformdirs"
 urls.Source = "https://github.com/platformdirs/platformdirs"
 urls.Tracker = "https://github.com/platformdirs/platformdirs/issues"
 requires-python = ">=3.7"
+dependencies = [
+  "typing-extensions; python_version < '3.8'"
+]
 optional-dependencies.test = [
   "appdirs==1.4.4",
   "covdefaults>=2.2.2",

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -7,11 +7,13 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-if sys.version_info >= (3, 8):  # pragma: no cover (py38+)
-    from typing import Literal
-else:  # pragma: no cover (py38+)
-    from typing_extensions import Literal
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 8):  # pragma: no cover (py38+)
+        from typing import Literal
+    else:  # pragma: no cover (py38+)
+        from typing_extensions import Literal
 
 from .api import PlatformDirsABC
 from .version import __version__

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -7,13 +7,11 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    if sys.version_info >= (3, 8):  # pragma: no cover (py38+)
-        from typing import Literal
-    else:  # pragma: no cover (py38+)
-        from typing_extensions import Literal
+if sys.version_info >= (3, 8):  # pragma: no cover (py38+)
+    from typing import Literal
+else:  # pragma: no cover (py38+)
+    from typing_extensions import Literal
 
 from .api import PlatformDirsABC
 from .version import __version__


### PR DESCRIPTION
Fixes #122: When importing platformdirs on Python < 3.8, typing_extensions might not be installed. Which would cause an import error. 

This adds typing-extensions as a dependency when using < python3.8