### PR TITLE
*_config_dir -> "*/Library/Application Support" (macOS), fixes #98

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 platformdirs Changelog
 ======================
 
+platformdirs 3.0.0 (2023-02-05)
+-------------------------------
+- **BREAKING** Correct the config directory on OSX/macOS, again: "*/Library/Application Support" (#98)
+
 platformdirs 2.6.2 (2022-12-28)
 -------------------------------
 - Fix missing ``typing-extensions`` dependency.

--- a/src/platformdirs/macos.py
+++ b/src/platformdirs/macos.py
@@ -25,13 +25,13 @@ class MacOS(PlatformDirsABC):
 
     @property
     def user_config_dir(self) -> str:
-        """:return: config directory tied to the user, e.g. ``~/Library/Preferences/$appname/$version``"""
-        return self._append_app_name_and_version(os.path.expanduser("~/Library/Preferences/"))
+        """:return: config directory tied to the user, e.g. ``~/Library/Application Support/$appname/$version``"""
+        return self._append_app_name_and_version(os.path.expanduser("~/Library/Application Support/"))
 
     @property
     def site_config_dir(self) -> str:
-        """:return: config directory shared by the users, e.g. ``/Library/Preferences/$appname``"""
-        return self._append_app_name_and_version("/Library/Preferences")
+        """:return: config directory shared by the users, e.g. ``/Library/Application Support/$appname/$version``"""
+        return self._append_app_name_and_version("/Library/Application Support")
 
     @property
     def user_cache_dir(self) -> str:

--- a/tests/test_comp_with_appdirs.py
+++ b/tests/test_comp_with_appdirs.py
@@ -57,8 +57,6 @@ def test_compatibility(params: dict[str, Any], func: str) -> None:
     if sys.platform == "darwin":
         msg = {  # pragma: no cover
             "user_log_dir": "without appname produces NoneType error",
-            "site_config_dir": "ignores the version argument",
-            "user_config_dir": "uses Library/Preferences instead Application Support",
         }
         if func in msg:  # pragma: no cover
             pytest.skip(f"`appdirs.{func}` {msg[func]} on macOS")  # pragma: no cover


### PR DESCRIPTION
Also: fix a doc string.