### PR TITLE
site_cache_dir: use /var/tmp instead of /var/cache on unix

### DIFF
--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -96,9 +96,9 @@ class Unix(PlatformDirsABC):
     @property
     def site_cache_dir(self) -> str:
         """
-        :return: cache directory shared by users, e.g. ``/var/cache/$appname/$version``
+        :return: cache directory shared by users, e.g. ``/var/tmp/$appname/$version``
         """
-        return self._append_app_name_and_version("/var/cache")
+        return self._append_app_name_and_version("/var/tmp")
 
     @property
     def user_state_dir(self) -> str:


### PR DESCRIPTION
Turns out `/var/cache` might be non-writable by regular users (e.g. on ubuntu), so we are better off using `/var/tmp` which is and it is what was suggested in original appdirs discussion in https://github.com/ActiveState/appdirs/issues/77

`site_cache_dir` was introduced very recently and it seems fine to make this breaking change right now.

Related https://github.com/platformdirs/platformdirs/pull/145