### PR TITLE
Add option to create directories

### DIFF
--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -49,15 +49,23 @@ def user_data_dir(
     appauthor: str | None | Literal[False] = None,
     version: str | None = None,
     roaming: bool = False,
+    ensure_exists: bool = False,
 ) -> str:
     """
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
-    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.version>`.
+    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.roaming>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: data directory tied to the user
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, roaming=roaming).user_data_dir
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        roaming=roaming,
+        ensure_exists=ensure_exists,
+    ).user_data_dir
 
 
 def site_data_dir(
@@ -65,15 +73,23 @@ def site_data_dir(
     appauthor: str | None | Literal[False] = None,
     version: str | None = None,
     multipath: bool = False,
+    ensure_exists: bool = False,
 ) -> str:
     """
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param multipath: See `roaming <platformdirs.api.PlatformDirsABC.multipath>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: data directory shared by users
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, multipath=multipath).site_data_dir
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        multipath=multipath,
+        ensure_exists=ensure_exists,
+    ).site_data_dir
 
 
 def user_config_dir(
@@ -81,15 +97,23 @@ def user_config_dir(
     appauthor: str | None | Literal[False] = None,
     version: str | None = None,
     roaming: bool = False,
+    ensure_exists: bool = False,
 ) -> str:
     """
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
-    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.version>`.
+    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.roaming>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: config directory tied to the user
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, roaming=roaming).user_config_dir
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        roaming=roaming,
+        ensure_exists=ensure_exists,
+    ).user_config_dir
 
 
 def site_config_dir(
@@ -97,15 +121,23 @@ def site_config_dir(
     appauthor: str | None | Literal[False] = None,
     version: str | None = None,
     multipath: bool = False,
+    ensure_exists: bool = False,
 ) -> str:
     """
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param multipath: See `roaming <platformdirs.api.PlatformDirsABC.multipath>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: config directory shared by the users
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, multipath=multipath).site_config_dir
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        multipath=multipath,
+        ensure_exists=ensure_exists,
+    ).site_config_dir
 
 
 def user_cache_dir(
@@ -113,15 +145,23 @@ def user_cache_dir(
     appauthor: str | None | Literal[False] = None,
     version: str | None = None,
     opinion: bool = True,
+    ensure_exists: bool = False,
 ) -> str:
     """
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param opinion: See `roaming <platformdirs.api.PlatformDirsABC.opinion>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: cache directory tied to the user
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, opinion=opinion).user_cache_dir
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        opinion=opinion,
+        ensure_exists=ensure_exists,
+    ).user_cache_dir
 
 
 def site_cache_dir(
@@ -129,15 +169,23 @@ def site_cache_dir(
     appauthor: str | None | Literal[False] = None,
     version: str | None = None,
     opinion: bool = True,
+    ensure_exists: bool = False,
 ) -> str:
     """
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param opinion: See `opinion <platformdirs.api.PlatformDirsABC.opinion>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: cache directory tied to the user
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, opinion=opinion).site_cache_dir
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        opinion=opinion,
+        ensure_exists=ensure_exists,
+    ).site_cache_dir
 
 
 def user_state_dir(
@@ -145,15 +193,23 @@ def user_state_dir(
     appauthor: str | None | Literal[False] = None,
     version: str | None = None,
     roaming: bool = False,
+    ensure_exists: bool = False,
 ) -> str:
     """
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
-    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.version>`.
+    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.roaming>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: state directory tied to the user
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, roaming=roaming).user_state_dir
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        roaming=roaming,
+        ensure_exists=ensure_exists,
+    ).user_state_dir
 
 
 def user_log_dir(
@@ -161,15 +217,23 @@ def user_log_dir(
     appauthor: str | None | Literal[False] = None,
     version: str | None = None,
     opinion: bool = True,
+    ensure_exists: bool = False,
 ) -> str:
     """
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param opinion: See `roaming <platformdirs.api.PlatformDirsABC.opinion>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: log directory tied to the user
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, opinion=opinion).user_log_dir
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        opinion=opinion,
+        ensure_exists=ensure_exists,
+    ).user_log_dir
 
 
 def user_documents_dir() -> str:
@@ -184,15 +248,23 @@ def user_runtime_dir(
     appauthor: str | None | Literal[False] = None,
     version: str | None = None,
     opinion: bool = True,
+    ensure_exists: bool = False,
 ) -> str:
     """
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param opinion: See `opinion <platformdirs.api.PlatformDirsABC.opinion>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: runtime directory tied to the user
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, opinion=opinion).user_runtime_dir
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        opinion=opinion,
+        ensure_exists=ensure_exists,
+    ).user_runtime_dir
 
 
 def user_data_path(
@@ -200,15 +272,23 @@ def user_data_path(
     appauthor: str | None | Literal[False] = None,
     version: str | None = None,
     roaming: bool = False,
+    ensure_exists: bool = False,
 ) -> Path:
     """
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
-    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.version>`.
+    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.roaming>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: data path tied to the user
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, roaming=roaming).user_data_path
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        roaming=roaming,
+        ensure_exists=ensure_exists,
+    ).user_data_path
 
 
 def site_data_path(
@@ -216,15 +296,23 @@ def site_data_path(
     appauthor: str | None | Literal[False] = None,
     version: str | None = None,
     multipath: bool = False,
+    ensure_exists: bool = False,
 ) -> Path:
     """
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param multipath: See `multipath <platformdirs.api.PlatformDirsABC.multipath>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: data path shared by users
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, multipath=multipath).site_data_path
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        multipath=multipath,
+        ensure_exists=ensure_exists,
+    ).site_data_path
 
 
 def user_config_path(
@@ -232,15 +320,23 @@ def user_config_path(
     appauthor: str | None | Literal[False] = None,
     version: str | None = None,
     roaming: bool = False,
+    ensure_exists: bool = False,
 ) -> Path:
     """
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
-    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.version>`.
+    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.roaming>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: config path tied to the user
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, roaming=roaming).user_config_path
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        roaming=roaming,
+        ensure_exists=ensure_exists,
+    ).user_config_path
 
 
 def site_config_path(
@@ -248,15 +344,23 @@ def site_config_path(
     appauthor: str | None | Literal[False] = None,
     version: str | None = None,
     multipath: bool = False,
+    ensure_exists: bool = False,
 ) -> Path:
     """
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param multipath: See `roaming <platformdirs.api.PlatformDirsABC.multipath>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: config path shared by the users
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, multipath=multipath).site_config_path
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        multipath=multipath,
+        ensure_exists=ensure_exists,
+    ).site_config_path
 
 
 def site_cache_path(
@@ -264,15 +368,23 @@ def site_cache_path(
     appauthor: str | None | Literal[False] = None,
     version: str | None = None,
     opinion: bool = True,
+    ensure_exists: bool = False,
 ) -> Path:
     """
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param opinion: See `opinion <platformdirs.api.PlatformDirsABC.opinion>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: cache directory tied to the user
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, opinion=opinion).site_cache_path
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        opinion=opinion,
+        ensure_exists=ensure_exists,
+    ).site_cache_path
 
 
 def user_cache_path(
@@ -280,15 +392,23 @@ def user_cache_path(
     appauthor: str | None | Literal[False] = None,
     version: str | None = None,
     opinion: bool = True,
+    ensure_exists: bool = False,
 ) -> Path:
     """
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param opinion: See `roaming <platformdirs.api.PlatformDirsABC.opinion>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: cache path tied to the user
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, opinion=opinion).user_cache_path
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        opinion=opinion,
+        ensure_exists=ensure_exists,
+    ).user_cache_path
 
 
 def user_state_path(
@@ -296,15 +416,23 @@ def user_state_path(
     appauthor: str | None | Literal[False] = None,
     version: str | None = None,
     roaming: bool = False,
+    ensure_exists: bool = False,
 ) -> Path:
     """
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
-    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.version>`.
+    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.roaming>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: state path tied to the user
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, roaming=roaming).user_state_path
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        roaming=roaming,
+        ensure_exists=ensure_exists,
+    ).user_state_path
 
 
 def user_log_path(
@@ -312,15 +440,23 @@ def user_log_path(
     appauthor: str | None | Literal[False] = None,
     version: str | None = None,
     opinion: bool = True,
+    ensure_exists: bool = False,
 ) -> Path:
     """
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param opinion: See `roaming <platformdirs.api.PlatformDirsABC.opinion>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: log path tied to the user
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, opinion=opinion).user_log_path
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        opinion=opinion,
+        ensure_exists=ensure_exists,
+    ).user_log_path
 
 
 def user_documents_path() -> Path:
@@ -335,15 +471,23 @@ def user_runtime_path(
     appauthor: str | None | Literal[False] = None,
     version: str | None = None,
     opinion: bool = True,
+    ensure_exists: bool = False,
 ) -> Path:
     """
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param opinion: See `opinion <platformdirs.api.PlatformDirsABC.opinion>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: runtime path tied to the user
     """
-    return PlatformDirs(appname=appname, appauthor=appauthor, version=version, opinion=opinion).user_runtime_path
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        opinion=opinion,
+        ensure_exists=ensure_exists,
+    ).user_runtime_path
 
 
 __all__ = [

--- a/src/platformdirs/android.py
+++ b/src/platformdirs/android.py
@@ -12,8 +12,9 @@ from .api import PlatformDirsABC
 class Android(PlatformDirsABC):
     """
     Follows the guidance `from here <https://android.stackexchange.com/a/216132>`_. Makes use of the
-    `appname <platformdirs.api.PlatformDirsABC.appname>` and
-    `version <platformdirs.api.PlatformDirsABC.version>`.
+    `appname <platformdirs.api.PlatformDirsABC.appname>`,
+    `version <platformdirs.api.PlatformDirsABC.version>`,
+    `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     """
 
     @property

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -22,6 +22,7 @@ class PlatformDirsABC(ABC):
         roaming: bool = False,
         multipath: bool = False,
         opinion: bool = True,
+        ensure_exists: bool = False,
     ):
         """
         Create a new platform directory.
@@ -32,6 +33,7 @@ class PlatformDirsABC(ABC):
         :param roaming: See `roaming`.
         :param multipath: See `multipath`.
         :param opinion: See `opinion`.
+        :param ensure_exists: See `ensure_exists`.
         """
         self.appname = appname  #: The name of application.
         self.appauthor = appauthor
@@ -56,6 +58,11 @@ class PlatformDirsABC(ABC):
         returned. By default, the first item would only be returned.
         """
         self.opinion = opinion  #: A flag to indicating to use opinionated values.
+        self.ensure_exists = ensure_exists
+        """
+        Optionally create the directory (and any missing parents) upon access if it does not exist.
+        By default, no directories are created.
+        """
 
     def _append_app_name_and_version(self, *base: str) -> str:
         params = list(base[1:])
@@ -63,7 +70,13 @@ class PlatformDirsABC(ABC):
             params.append(self.appname)
             if self.version:
                 params.append(self.version)
-        return os.path.join(base[0], *params)
+        path = os.path.join(base[0], *params)
+        self._optionally_create_directory(path)
+        return path
+
+    def _optionally_create_directory(self, path: str) -> None:
+        if self.ensure_exists:
+            Path(path).mkdir(parents=True, exist_ok=True)
 
     @property
     @abstractmethod

--- a/src/platformdirs/macos.py
+++ b/src/platformdirs/macos.py
@@ -9,8 +9,9 @@ class MacOS(PlatformDirsABC):
     """
     Platform directories for the macOS operating system. Follows the guidance from `Apple documentation
     <https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html>`_.
-    Makes use of the `appname <platformdirs.api.PlatformDirsABC.appname>` and
-    `version <platformdirs.api.PlatformDirsABC.version>`.
+    Makes use of the `appname <platformdirs.api.PlatformDirsABC.appname>`,
+    `version <platformdirs.api.PlatformDirsABC.version>`,
+    `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     """
 
     @property

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -24,7 +24,8 @@ class Unix(PlatformDirsABC):
     `appname <platformdirs.api.PlatformDirsABC.appname>`,
     `version <platformdirs.api.PlatformDirsABC.version>`,
     `multipath <platformdirs.api.PlatformDirsABC.multipath>`,
-    `opinion <platformdirs.api.PlatformDirsABC.opinion>`.
+    `opinion <platformdirs.api.PlatformDirsABC.opinion>`,
+    `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     """
 
     @property

--- a/src/platformdirs/windows.py
+++ b/src/platformdirs/windows.py
@@ -17,7 +17,9 @@ class Windows(PlatformDirsABC):
     `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`,
     `version <platformdirs.api.PlatformDirsABC.version>`,
     `roaming <platformdirs.api.PlatformDirsABC.roaming>`,
-    `opinion <platformdirs.api.PlatformDirsABC.opinion>`."""
+    `opinion <platformdirs.api.PlatformDirsABC.opinion>`,
+    `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
+    """
 
     @property
     def user_data_dir(self) -> str:
@@ -41,7 +43,9 @@ class Windows(PlatformDirsABC):
                 params.append(opinion_value)
             if self.version:
                 params.append(self.version)
-        return os.path.join(path, *params)
+        path = os.path.join(path, *params)
+        self._optionally_create_directory(path)
+        return path
 
     @property
     def site_data_dir(self) -> str:
@@ -87,6 +91,7 @@ class Windows(PlatformDirsABC):
         path = self.user_data_dir
         if self.opinion:
             path = os.path.join(path, "Logs")
+            self._optionally_create_directory(path)
         return path
 
     @property

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -4,6 +4,7 @@ import importlib
 import os
 import sys
 import typing
+from pathlib import Path
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
@@ -120,3 +121,15 @@ def test_platform_non_linux(monkeypatch: MonkeyPatch) -> None:
             unix.Unix().user_runtime_dir
     finally:
         importlib.reload(unix)
+
+
+def test_ensure_exists_creates_folder(mocker: MockerFixture, tmp_path: Path) -> None:
+    mocker.patch.dict(os.environ, {"XDG_DATA_HOME": str(tmp_path)})
+    data_path = Unix(appname="acme", ensure_exists=True).user_data_path
+    assert data_path.exists()
+
+
+def test_folder_not_created_without_ensure_exists(mocker: MockerFixture, tmp_path: Path) -> None:
+    mocker.patch.dict(os.environ, {"XDG_DATA_HOME": str(tmp_path)})
+    data_path = Unix(appname="acme", ensure_exists=False).user_data_path
+    assert not data_path.exists()


### PR DESCRIPTION
Optionally create directories upon use, based on the `ensure_exists` argument.

Fixes #120

While documenting the `ensure_exists` argument on the different functions, I noticed a few spots where the `roaming` link was broken, so I fixed those.  I can back that out if you'd prefer.