### PR TITLE
platformdirs: introduce `user_videos_dir()`

### DIFF
--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -250,6 +250,13 @@ def user_pictures_dir() -> str:
     return PlatformDirs().user_pictures_dir
 
 
+def user_videos_dir() -> str:
+    """
+    :returns: videos directory tied to the user
+    """
+    return PlatformDirs().user_videos_dir
+
+
 def user_runtime_dir(
     appname: str | None = None,
     appauthor: str | None | Literal[False] = None,
@@ -480,6 +487,13 @@ def user_pictures_path() -> Path:
     return PlatformDirs().user_pictures_path
 
 
+def user_videos_path() -> Path:
+    """
+    :returns: videos path tied to the user
+    """
+    return PlatformDirs().user_videos_path
+
+
 def user_runtime_path(
     appname: str | None = None,
     appauthor: str | None | Literal[False] = None,
@@ -517,6 +531,7 @@ __all__ = [
     "user_log_dir",
     "user_documents_dir",
     "user_pictures_dir",
+    "user_videos_dir",
     "user_runtime_dir",
     "site_data_dir",
     "site_config_dir",
@@ -528,6 +543,7 @@ __all__ = [
     "user_log_path",
     "user_documents_path",
     "user_pictures_path",
+    "user_videos_path",
     "user_runtime_path",
     "site_data_path",
     "site_config_path",

--- a/src/platformdirs/__main__.py
+++ b/src/platformdirs/__main__.py
@@ -10,6 +10,7 @@ PROPS = (
     "user_log_dir",
     "user_documents_dir",
     "user_pictures_dir",
+    "user_videos_dir",
     "user_runtime_dir",
     "site_data_dir",
     "site_config_dir",

--- a/src/platformdirs/android.py
+++ b/src/platformdirs/android.py
@@ -80,6 +80,13 @@ class Android(PlatformDirsABC):
         return _android_pictures_folder()
 
     @property
+    def user_videos_dir(self) -> str:
+        """
+        :return: videos directory tied to the user e.g. ``/storage/emulated/0/DCIM/Camera``
+        """
+        return _android_videos_folder()
+
+    @property
     def user_runtime_dir(self) -> str:
         """
         :return: runtime directory tied to the user, same as `user_cache_dir` if not opinionated else ``tmp`` in it,
@@ -142,6 +149,22 @@ def _android_pictures_folder() -> str:
         pictures_dir = "/storage/emulated/0/Pictures"
 
     return pictures_dir
+
+
+@lru_cache(maxsize=1)
+def _android_videos_folder() -> str:
+    """:return: videos folder for the Android OS"""
+    # Get directories with pyjnius
+    try:
+        from jnius import autoclass
+
+        Context = autoclass("android.content.Context")  # noqa: N806
+        Environment = autoclass("android.os.Environment")  # noqa: N806
+        videos_dir: str = Context.getExternalFilesDir(Environment.DIRECTORY_DCIM).getAbsolutePath()
+    except Exception:
+        videos_dir = "/storage/emulated/0/DCIM/Camera"
+
+    return videos_dir
 
 
 __all__ = [

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -130,6 +130,11 @@ class PlatformDirsABC(ABC):
 
     @property
     @abstractmethod
+    def user_videos_dir(self) -> str:
+        """:return: videos directory tied to the user"""
+
+    @property
+    @abstractmethod
     def user_runtime_dir(self) -> str:
         """:return: runtime directory tied to the user"""
 
@@ -182,6 +187,11 @@ class PlatformDirsABC(ABC):
     def user_pictures_path(self) -> Path:
         """:return: pictures path tied to the user"""
         return Path(self.user_pictures_dir)
+
+    @property
+    def user_videos_path(self) -> Path:
+        """:return: videos path tied to the user"""
+        return Path(self.user_videos_dir)
 
     @property
     def user_runtime_path(self) -> Path:

--- a/src/platformdirs/macos.py
+++ b/src/platformdirs/macos.py
@@ -65,6 +65,11 @@ class MacOS(PlatformDirsABC):
         return os.path.expanduser("~/Pictures")
 
     @property
+    def user_videos_dir(self) -> str:
+        """:return: videos directory tied to the user, e.g. ``~/Movies``"""
+        return os.path.expanduser("~/Movies")
+
+    @property
     def user_runtime_dir(self) -> str:
         """:return: runtime directory tied to the user, e.g. ``~/Library/Caches/TemporaryItems/$appname/$version``"""
         return self._append_app_name_and_version(os.path.expanduser("~/Library/Caches/TemporaryItems"))

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -137,6 +137,13 @@ class Unix(PlatformDirsABC):
         return _get_user_media_dir("XDG_PICTURES_DIR", "~/Pictures")
 
     @property
+    def user_videos_dir(self) -> str:
+        """
+        :return: videos directory tied to the user, e.g. ``~/Videos``
+        """
+        return _get_user_media_dir("XDG_VIDEOS_DIR", "~/Videos")
+
+    @property
     def user_runtime_dir(self) -> str:
         """
         :return: runtime directory tied to the user, e.g. ``/run/user/$(id -u)/$appname/$version`` or

--- a/src/platformdirs/windows.py
+++ b/src/platformdirs/windows.py
@@ -109,6 +109,13 @@ class Windows(PlatformDirsABC):
         return os.path.normpath(get_win_folder("CSIDL_MYPICTURES"))
 
     @property
+    def user_videos_dir(self) -> str:
+        """
+        :return: videos directory tied to the user e.g. ``%USERPROFILE%\\Videos``
+        """
+        return os.path.normpath(get_win_folder("CSIDL_MYVIDEO"))
+
+    @property
     def user_runtime_dir(self) -> str:
         """
         :return: runtime directory tied to the user, e.g.
@@ -125,6 +132,9 @@ def get_win_folder_from_env_vars(csidl_name: str) -> str:
 
     if csidl_name == "CSIDL_MYPICTURES":  # does not have an environment name
         return os.path.join(os.path.normpath(os.environ["USERPROFILE"]), "Pictures")
+
+    if csidl_name == "CSIDL_MYVIDEO":  # does not have an environment name
+        return os.path.join(os.path.normpath(os.environ["USERPROFILE"]), "Videos")
 
     env_var_name = {
         "CSIDL_APPDATA": "APPDATA",
@@ -152,6 +162,7 @@ def get_win_folder_from_registry(csidl_name: str) -> str:
         "CSIDL_LOCAL_APPDATA": "Local AppData",
         "CSIDL_PERSONAL": "Personal",
         "CSIDL_MYPICTURES": "My Pictures",
+        "CSIDL_MYVIDEO": "My Video",
     }.get(csidl_name)
     if shell_folder_name is None:
         raise ValueError(f"Unknown CSIDL name: {csidl_name}")
@@ -172,6 +183,7 @@ def get_win_folder_via_ctypes(csidl_name: str) -> str:
         "CSIDL_LOCAL_APPDATA": 28,
         "CSIDL_PERSONAL": 5,
         "CSIDL_MYPICTURES": 39,
+        "CSIDL_MYVIDEO": 14,
     }.get(csidl_name)
     if csidl_const is None:
         raise ValueError(f"Unknown CSIDL name: {csidl_name}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ PROPS = (
     "user_log_dir",
     "user_documents_dir",
     "user_pictures_dir",
+    "user_videos_dir",
     "user_runtime_dir",
     "site_data_dir",
     "site_config_dir",

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -53,6 +53,7 @@ def test_android(mocker: MockerFixture, params: dict[str, Any], func: str) -> No
         "user_log_dir": f"/data/data/com.example/cache{suffix}{'' if params.get('opinion', True) is False else '/log'}",
         "user_documents_dir": "/storage/emulated/0/Documents",
         "user_pictures_dir": "/storage/emulated/0/Pictures",
+        "user_videos_dir": "/storage/emulated/0/DCIM/Camera",
         "user_runtime_dir": f"/data/data/com.example/cache{suffix}{'' if not params.get('opinion', True) else '/tmp'}",
     }
     expected = expected_map[func]

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -34,6 +34,7 @@ def test_macos(params: dict[str, Any], func: str) -> None:
         "user_log_dir": f"{home}/Library/Logs{suffix}",
         "user_documents_dir": f"{home}/Documents",
         "user_pictures_dir": f"{home}/Pictures",
+        "user_videos_dir": f"{home}/Movies",
         "user_runtime_dir": f"{home}/Library/Caches/TemporaryItems{suffix}",
     }
     expected = expected_map[func]

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -13,72 +13,55 @@ from pytest_mock import MockerFixture
 from platformdirs.unix import Unix
 
 
-def test_user_documents_dir(mocker: MockerFixture) -> None:
-    example_path = "/home/example/ExampleDocumentsFolder"
+@pytest.mark.parametrize("prop", ["user_documents_dir", "user_pictures_dir", "user_videos_dir"])
+def test_user_media_dir(mocker: MockerFixture, prop: str) -> None:
+    example_path = "/home/example/ExampleMediaFolder"
     mock = mocker.patch("platformdirs.unix._get_user_dirs_folder")
     mock.return_value = example_path
-    assert Unix().user_documents_dir == example_path
+    assert getattr(Unix(), prop) == example_path
 
 
-def test_user_documents_dir_env_var(mocker: MockerFixture) -> None:
-    # Mock documents dir not being in user-dirs.dirs file
+@pytest.mark.parametrize(
+    "env_var,prop",
+    [
+        pytest.param("XDG_DOCUMENTS_DIR", "user_documents_dir", id="user_documents_dir"),
+        pytest.param("XDG_PICTURES_DIR", "user_pictures_dir", id="user_pictures_dir"),
+        pytest.param("XDG_VIDEOS_DIR", "user_videos_dir", id="user_videos_dir"),
+    ],
+)
+def test_user_media_dir_env_var(mocker: MockerFixture, env_var: str, prop: str) -> None:
+    # Mock media dir not being in user-dirs.dirs file
     mock = mocker.patch("platformdirs.unix._get_user_dirs_folder")
     mock.return_value = None
 
-    example_path = "/home/example/ExampleDocumentsFolder"
-    mocker.patch.dict(os.environ, {"XDG_DOCUMENTS_DIR": example_path})
+    example_path = "/home/example/ExampleMediaFolder"
+    mocker.patch.dict(os.environ, {env_var: example_path})
 
-    assert Unix().user_documents_dir == example_path
+    assert getattr(Unix(), prop) == example_path
 
 
-def test_user_documents_dir_default(mocker: MockerFixture) -> None:
-    # Mock documents dir not being in user-dirs.dirs file
+@pytest.mark.parametrize(
+    "env_var,prop,default_abs_path",
+    [
+        pytest.param("XDG_DOCUMENTS_DIR", "user_documents_dir", "/home/example/Documents", id="user_documents_dir"),
+        pytest.param("XDG_PICTURES_DIR", "user_pictures_dir", "/home/example/Pictures", id="user_pictures_dir"),
+        pytest.param("XDG_VIDEOS_DIR", "user_videos_dir", "/home/example/Videos", id="user_videos_dir"),
+    ],
+)
+def test_user_media_dir_default(mocker: MockerFixture, env_var: str, prop: str, default_abs_path: str) -> None:
+    # Mock media dir not being in user-dirs.dirs file
     mock = mocker.patch("platformdirs.unix._get_user_dirs_folder")
     mock.return_value = None
 
-    # Mock no XDG_DOCUMENTS_DIR env variable being set
-    mocker.patch.dict(os.environ, {"XDG_DOCUMENTS_DIR": ""})
+    # Mock no XDG env variable being set
+    mocker.patch.dict(os.environ, {env_var: ""})
 
     # Mock home directory
     mocker.patch.dict(os.environ, {"HOME": "/home/example"})
     # Mock home directory for running the test on Windows
     mocker.patch.dict(os.environ, {"USERPROFILE": "/home/example"})
 
-    assert Unix().user_documents_dir == "/home/example/Documents"
-
-
-def test_user_pictures_dir(mocker: MockerFixture) -> None:
-    example_path = "/home/example/ExamplePicturesFolder"
-    mock = mocker.patch("platformdirs.unix._get_user_dirs_folder")
-    mock.return_value = example_path
-    assert Unix().user_pictures_dir == example_path
-
-
-def test_user_pictures_dir_env_var(mocker: MockerFixture) -> None:
-    # Mock pictures dir not being in user-dirs.dirs file
-    mock = mocker.patch("platformdirs.unix._get_user_dirs_folder")
-    mock.return_value = None
-
-    example_path = "/home/example/ExamplePicturesFolder"
-    mocker.patch.dict(os.environ, {"XDG_PICTURES_DIR": example_path})
-
-    assert Unix().user_pictures_dir == example_path
-
-
-def test_user_pictures_dir_default(mocker: MockerFixture) -> None:
-    # Mock pictures dir not being in user-dirs.dirs file
-    mock = mocker.patch("platformdirs.unix._get_user_dirs_folder")
-    mock.return_value = None
-
-    # Mock no XDG_PICTURES_DIR env variable being set
-    mocker.patch.dict(os.environ, {"XDG_PICTURES_DIR": ""})
-
-    # Mock home directory
-    mocker.patch.dict(os.environ, {"HOME": "/home/example"})
-    # Mock home directory for running the test on Windows
-    mocker.patch.dict(os.environ, {"USERPROFILE": "/home/example"})
-
-    assert Unix().user_pictures_dir == "/home/example/Pictures"
+    assert getattr(Unix(), prop) == default_abs_path
 
 
 class XDGVariable(typing.NamedTuple):


### PR DESCRIPTION
Introduces the means to acquire the user's video directory path.

Feature suggested in #141.

I have written tests, but have decided to parametrize the `Unix`-related user media-related directory tests as the only differences I found between them are the environment variable and the default directory path that they would use. I have tested it using the interactive Python shell versions 3.9 & 3.11 on Windows, Linux, and MacOS and was given the expected results on my machine when calling the function. I don't have an Android device so I've been unable to test it in a similar fashion as I did the other OSs.

**NOTE**: For Android, I decided to use `Environment.DIRECTORY_DCIM` constant since it is the ["traditional location for pictures and videos when mounting the device as a camera"](https://developer.android.com/reference/android/os/Environment#DIRECTORY_DCIM). However, the developer docs also mention that videos could also be [stored in the `Movies/` and `Pictures/` directories as well](https://developer.android.com/training/data-storage/shared/media#media_store), so I thought I should mention this. I am somewhat sure that the default path for user-related videos should be `/storage/emulated/0/DCIM/Camera` but if not let me know.

Some other references I thought I should mention:
Android:
- Where I found the default directory path: https://forums.androidcentral.com/threads/location-of-videos.518708/

MacOS:
- `~/Movies`: https://github.com/adrg/xdg/blob/master/README.md#xdg-user-directories

Unix:
- `XDG_VIDEOS_DIR` & `~/Videos`: https://wiki.archlinux.org/title/XDG_user_directories

Windows:
- `CSIDL_MYVIDEO`
  - https://learn.microsoft.com/en-us/windows/win32/shell/csidl
  - https://github.com/Alexpux/mingw-w64/blob/master/mingw-w64-headers/include/shlobj.h#L32
- `My Video` shell folder name & `%USERPROFILE%\Videos`: found while using `regedit`
  - Also found the default directory path here: https://github.com/adrg/xdg/blob/master/README.md#xdg-user-directories