### PR TITLE
removing Windows versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ For example, if running on macOS, you should use::
 
     ~/Library/Application Support/<AppName>
 
-If on Windows (at least English Win XP) that should be::
+If on Windows (at least English Win) that should be::
 
     C:\Documents and Settings\<User>\Application Data\Local Settings\<AppAuthor>\<AppName>
 
@@ -71,7 +71,7 @@ On macOS:
     >>> user_runtime_dir(appname, appauthor)
     '/Users/trentm/Library/Caches/TemporaryItems/SuperApp'
 
-On Windows 7:
+On Windows:
 
 .. code-block:: pycon
 


### PR DESCRIPTION
I took a look at Windows docs and the code, as far as I can tell none of the paths change between Windows versions.
I've tested this also on my Windows 11 machine.

So I just went with removing all the Windows versions in `README.rst`.

closes #135 