### PR TITLE
Have user_runtime_dir return /var/run/user/uid for *BSD

### DIFF
--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -150,11 +150,17 @@ class Unix(PlatformDirsABC):
     def user_runtime_dir(self) -> str:
         """
         :return: runtime directory tied to the user, e.g. ``/run/user/$(id -u)/$appname/$version`` or
-         ``$XDG_RUNTIME_DIR/$appname/$version``
+         ``$XDG_RUNTIME_DIR/$appname/$version``.
+
+         For FreeBSD/OpenBSD/NetBSD, it would return ``/var/run/user/$(id -u)/$appname/$version`` if
+         ``$XDG_RUNTIME_DIR`` is not set.
         """
         path = os.environ.get("XDG_RUNTIME_DIR", "")
         if not path.strip():
-            path = f"/run/user/{getuid()}"
+            if sys.platform.startswith(("freebsd", "openbsd", "netbsd")):
+                path = f"/var/run/user/{getuid()}"
+            else:
+                path = f"/run/user/{getuid()}"
         return self._append_app_name_and_version(path)
 
     @property

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -142,6 +142,20 @@ def test_xdg_variable_custom_value(monkeypatch: pytest.MonkeyPatch, dirs_instanc
     assert result == "/custom-dir"
 
 
+@pytest.mark.usefixtures("_getuid")
+def test_platform_on_bsd(monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture) -> None:
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    mocker.patch("sys.platform", "freebsd")
+    expected_path = "/var/run/user/1234"
+    assert Unix().user_runtime_dir == expected_path
+
+    mocker.patch("sys.platform", "openbsd")
+    assert Unix().user_runtime_dir == expected_path
+
+    mocker.patch("sys.platform", "netbsd")
+    assert Unix().user_runtime_dir == expected_path
+
+
 def test_platform_on_win32(monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture) -> None:
     monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
     mocker.patch("sys.platform", "win32")


### PR DESCRIPTION
Partially addresses #190 by having `user_runtime_dir()` return /var/run/user/... for the 3 most popular BSD systems

I just check to see if we are using FreeBSD/OpenBSD/NetBSD by using `sys.platform`. Unless other BSD-based systems use the kernel names of these OSs (since `sys.platform` essentially returns a lowercase version of `uname -s` with its major version appended to it), they will still fallback to `/run/user/`.

References:
FreeBSD's kernel name: from reading https://docs.python.org/3/library/sys.html#sys.platform
OpenBSD's kernel name: from firing up a VM and running `uname -s`
NetBSD's kernel name: an image search of `uname` being ran.