### PR TITLE
Support setuptools-scm 6.x

### DIFF
--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -9,12 +9,8 @@ import sys
 from typing import TYPE_CHECKING
 
 from .api import PlatformDirsABC
-
-try:
-    from .version import __version__
-    from .version import __version_tuple__ as __version_info__
-except:
-    from .version import version_tuple as __version_info__
+from .version import version
+from .version import version_tuple as __version_info__
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -9,8 +9,12 @@ import sys
 from typing import TYPE_CHECKING
 
 from .api import PlatformDirsABC
-from .version import __version__
-from .version import __version_tuple__ as __version_info__
+try:
+    from .version import __version__
+    from .version import __version_tuple__ as __version_info__
+except:
+    from .version import version
+    from .version import version_tuple as __version_info__
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -9,7 +9,6 @@ import sys
 from typing import TYPE_CHECKING
 
 from .api import PlatformDirsABC
-from .version import version
 from .version import version_tuple as __version_info__
 
 if TYPE_CHECKING:

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -9,11 +9,11 @@ import sys
 from typing import TYPE_CHECKING
 
 from .api import PlatformDirsABC
+
 try:
     from .version import __version__
     from .version import __version_tuple__ as __version_info__
 except:
-    from .version import version
     from .version import version_tuple as __version_info__
 
 if TYPE_CHECKING:


### PR DESCRIPTION
hatch-vcs 0.3.0 depends on setuptools-scm 6.4.0+. Since setuptools-scm 6.x and 7.x generates different version.py (see below), the following error occurs with setuptools-scm 6.x. Therefore, we add a workaround to support both versions.

With setuptools-scm 6.4.2:
```
% cat src/platformdirs/version.py
# coding: utf-8
# file generated by setuptools_scm
# don't change, don't track in version control
version = '3.8.0'
version_tuple = (3, 8, 0)
```

With setuptools-scm 7.1.0:
```
% cat src/platformdirs/version.py
# file generated by setuptools_scm
# don't change, don't track in version control
__version__ = version = '3.8.0'
__version_tuple__ = version_tuple = (3, 8, 0)
```

The error without this workaround:
```
>>> import platformdirs
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.11/site-packages/platformdirs/__init__.py", line 12, in <module>
    from .version import __version__
ImportError: cannot import name '__version__' from 'platformdirs.version' (/usr/local/lib/python3.11/site-packages/platformdirs/version.py)
```

Reference:	https://github.com/pypa/setuptools_scm/commit/b45e19f9f275a31873fd5e07faabef16fd0bbec0