### PR TITLE
BSD: provide a fallback for user_runtime_dir

### DIFF
--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -153,12 +153,15 @@ class Unix(PlatformDirsABC):
          ``$XDG_RUNTIME_DIR/$appname/$version``.
 
          For FreeBSD/OpenBSD/NetBSD, it would return ``/var/run/user/$(id -u)/$appname/$version`` if
-         ``$XDG_RUNTIME_DIR`` is not set.
+         exists, otherwise ``/tmp/runtime-$(id -u)/$appname/$version``, if``$XDG_RUNTIME_DIR``
+         is not set.
         """
         path = os.environ.get("XDG_RUNTIME_DIR", "")
         if not path.strip():
             if sys.platform.startswith(("freebsd", "openbsd", "netbsd")):
                 path = f"/var/run/user/{getuid()}"
+                if not Path(path).exists():
+                    path = f"/tmp/runtime-{getuid()}"  # noqa: S108
             else:
                 path = f"/run/user/{getuid()}"
         return self._append_app_name_and_version(path)

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -143,17 +143,16 @@ def test_xdg_variable_custom_value(monkeypatch: pytest.MonkeyPatch, dirs_instanc
 
 
 @pytest.mark.usefixtures("_getuid")
-def test_platform_on_bsd(monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture) -> None:
+@pytest.mark.parametrize("platform", ["freebsd", "openbsd", "netbsd"])
+def test_platform_on_bsd(monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture, platform: str) -> None:
     monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
-    mocker.patch("sys.platform", "freebsd")
-    expected_path = "/var/run/user/1234"
-    assert Unix().user_runtime_dir == expected_path
+    mocker.patch("sys.platform", platform)
 
-    mocker.patch("sys.platform", "openbsd")
-    assert Unix().user_runtime_dir == expected_path
+    mocker.patch("pathlib.Path.exists", return_value=True)
+    assert Unix().user_runtime_dir == "/var/run/user/1234"
 
-    mocker.patch("sys.platform", "netbsd")
-    assert Unix().user_runtime_dir == expected_path
+    mocker.patch("pathlib.Path.exists", return_value=False)
+    assert Unix().user_runtime_dir == "/tmp/runtime-1234"  # noqa: S108
 
 
 def test_platform_on_win32(monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture) -> None:


### PR DESCRIPTION
On *BSD platforms, the /var/run/user/{uid} directory is not always created. Provide a fallback of /tmp/runtime-{uid} if that path does not exist.