### PR TITLE
unix: Optionally create the opinionated log/ in `user_log_dir()`

### DIFF
--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -119,6 +119,7 @@ class Unix(PlatformDirsABC):
         path = self.user_state_dir
         if self.opinion:
             path = os.path.join(path, "log")  # noqa: PTH118
+            self._optionally_create_directory(path)
         return path
 
     @property


### PR DESCRIPTION
Resolves #207.

In `user_log_dir()`, we were using the result of `user_state_dir()` which would optionally create its directory path, but we weren't optionally creating the opinionated log/ directory.