### PR TITLE
README: Fix CI badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 The problem
 ===========
 
-.. image:: https://github.com/platformdirs/platformdirs/workflows/Test/badge.svg
-   :target: https://github.com/platformdirs/platformdirs/actions?query=workflow%3ATest
+.. image:: https://github.com/platformdirs/platformdirs/actions/workflows/check.yml/badge.svg
+   :target: https://github.com/platformdirs/platformdirs/actions
 
 When writing desktop application, finding the right location to store user data
 and configuration varies per platform. Even for single-platform apps, there


### PR DESCRIPTION
The badge and the link are broken. Fix 'em.

# Before

![image](https://github.com/platformdirs/platformdirs/assets/1324225/04990326-c25b-4629-94f0-675ee1f63089)

# After

![image](https://github.com/platformdirs/platformdirs/assets/1324225/54a654bd-7ed8-43d5-8003-ec1d6081aff9)
