### PR TITLE
Improve developer experience using Hatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ tmp/
 build/
 dist/
 .tox/
+.coverage
 /src/platformdirs/version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,26 @@ build.hooks.vcs.version-file = "src/platformdirs/version.py"
 build.targets.sdist.include = ["/src", "/tests", "/tox.ini"]
 version.source = "vcs"
 
+[tool.hatch.envs.default]
+features = ["docs", "test"]
+
+[tool.hatch.envs.default.scripts]
+test = """\
+  pytest --cov platformdirs --cov tests \
+  --cov-config=pyproject.toml --no-cov-on-fail \
+  --cov-report term-missing:skip-covered --cov-context=test \
+  --cov-report html:htmlcov \
+  tests
+  """
+check-types = [
+  "mypy --strict src",
+  "mypy --strict tests",
+]
+build-docs = [
+  "proselint docs/*.rst",
+  "sphinx-build -b html docs build",
+]
+
 [tool.black]
 line-length = 120
 


### PR DESCRIPTION
This sets up the default Hatch environment to also install the "docs" and "test" dependencies (see ["features"](https://hatch.pypa.io/latest/config/environment/overview/#features)). It also adds some [Hatch scripts](https://hatch.pypa.io/latest/config/environment/overview/#scripts) to those environments. This allows the following functionality:

```bash
$ hatch shell  # creates & activates a virtualenv for this project, with all dev dependencies
$ hatch run test  # runs pytest in that virtualenv
$ hatch run check-types  # run mypy in that virtualenv
$ hatch run build-docs  # builds HTML documentation
```