### PR TITLE
Add support for Homebrew-installed software

### DIFF
--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -59,8 +59,7 @@ class PlatformDirsABC(ABC):
         self.multipath = multipath
         """
         An optional parameter which indicates that the entire list of data dirs should be returned.
-        By default, the first item would only be returned. This is only applicable for Linux/Unix systems,
-        as well as macOS systems where `Homebrew <https://brew.sh>`_ is installed.
+        By default, the first item would only be returned.
         """
         self.opinion = opinion  #: A flag to indicating to use opinionated values.
         self.ensure_exists = ensure_exists

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -58,8 +58,9 @@ class PlatformDirsABC(ABC):
         """
         self.multipath = multipath
         """
-        An optional parameter only applicable to Unix/Linux which indicates that the entire list of data dirs should be
-        returned. By default, the first item would only be returned.
+        An optional parameter which indicates that the entire list of data dirs should be returned.
+        By default, the first item would only be returned. This is only applicable for Linux/Unix systems,
+        as well as macOS systems where `Homebrew <https://brew.sh>`_ is installed.
         """
         self.opinion = opinion  #: A flag to indicating to use opinionated values.
         self.ensure_exists = ensure_exists

--- a/src/platformdirs/macos.py
+++ b/src/platformdirs/macos.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os.path
+import sys
 
 from .api import PlatformDirsABC
 
@@ -22,8 +23,21 @@ class MacOS(PlatformDirsABC):
 
     @property
     def site_data_dir(self) -> str:
-        """:return: data directory shared by users, e.g. ``/Library/Application Support/$appname/$version``"""
-        return self._append_app_name_and_version("/Library/Application Support")
+        """
+        :return: data directory shared by users, e.g. ``/Library/Application Support/$appname/$version``.
+          If we're using a Python binary managed by `Homebrew <https://brew.sh>`_, the directory
+          will be under the Homebrew prefix, e.g. ``/opt/homebrew/share/$appname/$version``.
+          If `multipath <platformdirs.api.PlatformDirsABC.multipath>` is enabled and we're in Homebrew,
+          the response is a multi-path string separated by ":", e.g.
+          ``/opt/homebrew/share/$appname/$version:/Library/Application Support/$appname/$version``
+        """
+        path_list = [self._append_app_name_and_version("/Library/Application Support")]
+        is_homebrew = sys.prefix.startswith("/opt/homebrew")
+        if is_homebrew:
+            path_list.insert(0, self._append_app_name_and_version("/opt/homebrew/share"))
+        if self.multipath:
+            return os.pathsep.join(path_list)
+        return path_list[0]
 
     @property
     def user_config_dir(self) -> str:
@@ -42,8 +56,21 @@ class MacOS(PlatformDirsABC):
 
     @property
     def site_cache_dir(self) -> str:
-        """:return: cache directory shared by users, e.g. ``/Library/Caches/$appname/$version``"""
-        return self._append_app_name_and_version("/Library/Caches")
+        """
+        :return: cache directory shared by users, e.g. ``/Library/Caches/$appname/$version``.
+          If we're using a Python binary managed by `Homebrew <https://brew.sh>`_, the directory
+          will be under the Homebrew prefix, e.g. ``/opt/homebrew/var/cache/$appname/$version``.
+          If `multipath <platformdirs.api.PlatformDirsABC.multipath>` is enabled and we're in Homebrew,
+          the response is a multi-path string separated by ":", e.g.
+          ``/opt/homebrew/var/cache/$appname/$version:/Library/Caches/$appname/$version``
+        """
+        path_list = [self._append_app_name_and_version("/Library/Caches")]
+        is_homebrew = sys.prefix.startswith("/opt/homebrew")
+        if is_homebrew:
+            path_list.insert(0, self._append_app_name_and_version("/opt/homebrew/var/cache"))
+        if self.multipath:
+            return os.pathsep.join(path_list)
+        return path_list[0]
 
     @property
     def user_state_dir(self) -> str:

--- a/src/platformdirs/macos.py
+++ b/src/platformdirs/macos.py
@@ -31,10 +31,9 @@ class MacOS(PlatformDirsABC):
           the response is a multi-path string separated by ":", e.g.
           ``/opt/homebrew/share/$appname/$version:/Library/Application Support/$appname/$version``
         """
-        path_list = [self._append_app_name_and_version("/Library/Application Support")]
         is_homebrew = sys.prefix.startswith("/opt/homebrew")
-        if is_homebrew:
-            path_list.insert(0, self._append_app_name_and_version("/opt/homebrew/share"))
+        path_list = [self._append_app_name_and_version("/opt/homebrew/share")] if is_homebrew else []
+        path_list.append(self._append_app_name_and_version("/Library/Application Support"))
         if self.multipath:
             return os.pathsep.join(path_list)
         return path_list[0]
@@ -64,10 +63,9 @@ class MacOS(PlatformDirsABC):
           the response is a multi-path string separated by ":", e.g.
           ``/opt/homebrew/var/cache/$appname/$version:/Library/Caches/$appname/$version``
         """
-        path_list = [self._append_app_name_and_version("/Library/Caches")]
         is_homebrew = sys.prefix.startswith("/opt/homebrew")
-        if is_homebrew:
-            path_list.insert(0, self._append_app_name_and_version("/opt/homebrew/var/cache"))
+        path_list = [self._append_app_name_and_version("/opt/homebrew/var/cache")] if is_homebrew else []
+        path_list.append(self._append_app_name_and_version("/Library/Caches"))
         if self.multipath:
             return os.pathsep.join(path_list)
         return path_list[0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 if TYPE_CHECKING:
     from _pytest.fixtures import SubRequest
 
-PROPS = (
+USER_PROPS = (
     "user_data_dir",
     "user_config_dir",
     "user_cache_dir",
@@ -19,15 +19,25 @@ PROPS = (
     "user_videos_dir",
     "user_music_dir",
     "user_runtime_dir",
+)
+
+SITE_PROPS = (
     "site_data_dir",
     "site_config_dir",
     "site_cache_dir",
     "site_runtime_dir",
 )
 
+PROPS = USER_PROPS + SITE_PROPS
+
 
 @pytest.fixture(params=PROPS)
 def func(request: SubRequest) -> str:
+    return cast(str, request.param)
+
+
+@pytest.fixture(params=SITE_PROPS)
+def site_func(request: SubRequest) -> str:
     return cast(str, request.param)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 if TYPE_CHECKING:
     from _pytest.fixtures import SubRequest
 
-USER_PROPS = (
+PROPS = (
     "user_data_dir",
     "user_config_dir",
     "user_cache_dir",
@@ -19,25 +19,15 @@ USER_PROPS = (
     "user_videos_dir",
     "user_music_dir",
     "user_runtime_dir",
-)
-
-SITE_PROPS = (
     "site_data_dir",
     "site_config_dir",
     "site_cache_dir",
     "site_runtime_dir",
 )
 
-PROPS = USER_PROPS + SITE_PROPS
-
 
 @pytest.fixture(params=PROPS)
 def func(request: SubRequest) -> str:
-    return cast(str, request.param)
-
-
-@pytest.fixture(params=SITE_PROPS)
-def site_func(request: SubRequest) -> str:
     return cast(str, request.param)
 
 

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -13,6 +13,17 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
+@pytest.fixture(autouse=True)
+def _fix_os_pathsep(mocker: MockerFixture) -> None:
+    """
+    If we're not actually running on macOS, set `os.pathsep` to
+    what it should be on macOS.
+    """
+    if sys.platform != "darwin":
+        mocker.patch("os.pathsep", ":")
+        mocker.patch("os.path.pathsep", ":")
+
+
 @pytest.mark.parametrize(
     "params",
     [

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from platformdirs.macos import MacOS
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.mark.parametrize(
@@ -17,7 +21,17 @@ from platformdirs.macos import MacOS
         pytest.param({"appname": "foo", "version": "v1.0"}, id="app_name_version"),
     ],
 )
-def test_macos(params: dict[str, Any], func: str) -> None:
+def test_macos(mocker: MockerFixture, params: dict[str, Any], func: str) -> None:
+    # Make sure we are not in Homebrew
+    py_version = sys.version_info
+    mocker.patch(
+        "sys.prefix",
+        (
+            "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions"
+            f"/{py_version.major}.{py_version.minor}"
+        ),
+    )
+
     result = getattr(MacOS(**params), func)
 
     home = str(Path("~").expanduser())
@@ -42,6 +56,51 @@ def test_macos(params: dict[str, Any], func: str) -> None:
         "user_runtime_dir": f"{home}/Library/Caches/TemporaryItems{suffix}",
         "site_runtime_dir": f"{home}/Library/Caches/TemporaryItems{suffix}",
     }
+    expected = expected_map[func]
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.param({}, id="no_args"),
+        pytest.param({"appname": "foo"}, id="app_name"),
+        pytest.param({"appname": "foo", "version": "v1.0"}, id="app_name_version"),
+    ],
+)
+@pytest.mark.parametrize("multipath", [pytest.param(True, id="multipath"), pytest.param(False, id="singlepath")])
+def test_macos_homebrew(mocker: MockerFixture, params: dict[str, Any], multipath: bool, func: str) -> None:
+    mocker.patch("sys.prefix", "/opt/homebrew/opt/python")
+
+    result = getattr(MacOS(multipath=multipath, **params), func)
+
+    home = str(Path("~").expanduser())
+    suffix_elements = tuple(params[i] for i in ("appname", "version") if i in params)
+    suffix = os.sep.join(("", *suffix_elements)) if suffix_elements else ""  # noqa: PTH118
+
+    expected_map = {
+        "user_data_dir": f"{home}/Library/Application Support{suffix}",
+        "site_data_dir": f"/opt/homebrew/share{suffix}",
+        "user_config_dir": f"{home}/Library/Application Support{suffix}",
+        "site_config_dir": f"/opt/homebrew/share{suffix}",
+        "user_cache_dir": f"{home}/Library/Caches{suffix}",
+        "site_cache_dir": f"/opt/homebrew/var/cache{suffix}",
+        "user_state_dir": f"{home}/Library/Application Support{suffix}",
+        "user_log_dir": f"{home}/Library/Logs{suffix}",
+        "user_documents_dir": f"{home}/Documents",
+        "user_downloads_dir": f"{home}/Downloads",
+        "user_pictures_dir": f"{home}/Pictures",
+        "user_videos_dir": f"{home}/Movies",
+        "user_music_dir": f"{home}/Music",
+        "user_desktop_dir": f"{home}/Desktop",
+        "user_runtime_dir": f"{home}/Library/Caches/TemporaryItems{suffix}",
+        "site_runtime_dir": f"{home}/Library/Caches/TemporaryItems{suffix}",
+    }
+    if multipath:
+        expected_map["site_data_dir"] += f":/Library/Application Support{suffix}"
+        expected_map["site_config_dir"] += f":/Library/Application Support{suffix}"
+        expected_map["site_cache_dir"] += f":/Library/Caches{suffix}"
     expected = expected_map[func]
 
     assert result == expected

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -77,6 +77,15 @@ def test_macos(mocker: MockerFixture, params: dict[str, Any], func: str) -> None
         pytest.param({"appname": "foo", "version": "v1.0"}, id="app_name_version"),
     ],
 )
+@pytest.mark.parametrize(
+    "site_func",
+    [
+        "site_data_dir",
+        "site_config_dir",
+        "site_cache_dir",
+        "site_runtime_dir",
+    ],
+)
 @pytest.mark.parametrize("multipath", [pytest.param(True, id="multipath"), pytest.param(False, id="singlepath")])
 def test_macos_homebrew(mocker: MockerFixture, params: dict[str, Any], multipath: bool, site_func: str) -> None:
     mocker.patch("sys.prefix", "/opt/homebrew/opt/python")

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -16,10 +16,9 @@ if TYPE_CHECKING:
 @pytest.fixture(autouse=True)
 def _fix_os_pathsep(mocker: MockerFixture) -> None:
     """
-    If we're not actually running on macOS, set `os.pathsep` to
-    what it should be on macOS.
+    If we're not actually running on macOS, set `os.pathsep` to what it should be on macOS.
     """
-    if sys.platform != "darwin":
+    if sys.platform != "darwin":  # pragma: darwin no cover
         mocker.patch("os.pathsep", ":")
         mocker.patch("os.path.pathsep", ":")
 
@@ -35,13 +34,11 @@ def _fix_os_pathsep(mocker: MockerFixture) -> None:
 def test_macos(mocker: MockerFixture, params: dict[str, Any], func: str) -> None:
     # Make sure we are not in Homebrew
     py_version = sys.version_info
-    mocker.patch(
-        "sys.prefix",
-        (
-            "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions"
-            f"/{py_version.major}.{py_version.minor}"
-        ),
+    builtin_py_prefix = (
+        "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework"
+        f"/Versions/{py_version.major}.{py_version.minor}"
     )
+    mocker.patch("sys.prefix", builtin_py_prefix)
 
     result = getattr(MacOS(**params), func)
 
@@ -81,37 +78,25 @@ def test_macos(mocker: MockerFixture, params: dict[str, Any], func: str) -> None
     ],
 )
 @pytest.mark.parametrize("multipath", [pytest.param(True, id="multipath"), pytest.param(False, id="singlepath")])
-def test_macos_homebrew(mocker: MockerFixture, params: dict[str, Any], multipath: bool, func: str) -> None:
+def test_macos_homebrew(mocker: MockerFixture, params: dict[str, Any], multipath: bool, site_func: str) -> None:
     mocker.patch("sys.prefix", "/opt/homebrew/opt/python")
 
-    result = getattr(MacOS(multipath=multipath, **params), func)
+    result = getattr(MacOS(multipath=multipath, **params), site_func)
 
     home = str(Path("~").expanduser())
     suffix_elements = tuple(params[i] for i in ("appname", "version") if i in params)
     suffix = os.sep.join(("", *suffix_elements)) if suffix_elements else ""  # noqa: PTH118
 
     expected_map = {
-        "user_data_dir": f"{home}/Library/Application Support{suffix}",
         "site_data_dir": f"/opt/homebrew/share{suffix}",
-        "user_config_dir": f"{home}/Library/Application Support{suffix}",
         "site_config_dir": f"/opt/homebrew/share{suffix}",
-        "user_cache_dir": f"{home}/Library/Caches{suffix}",
         "site_cache_dir": f"/opt/homebrew/var/cache{suffix}",
-        "user_state_dir": f"{home}/Library/Application Support{suffix}",
-        "user_log_dir": f"{home}/Library/Logs{suffix}",
-        "user_documents_dir": f"{home}/Documents",
-        "user_downloads_dir": f"{home}/Downloads",
-        "user_pictures_dir": f"{home}/Pictures",
-        "user_videos_dir": f"{home}/Movies",
-        "user_music_dir": f"{home}/Music",
-        "user_desktop_dir": f"{home}/Desktop",
-        "user_runtime_dir": f"{home}/Library/Caches/TemporaryItems{suffix}",
         "site_runtime_dir": f"{home}/Library/Caches/TemporaryItems{suffix}",
     }
     if multipath:
         expected_map["site_data_dir"] += f":/Library/Application Support{suffix}"
         expected_map["site_config_dir"] += f":/Library/Application Support{suffix}"
         expected_map["site_cache_dir"] += f":/Library/Caches{suffix}"
-    expected = expected_map[func]
+    expected = expected_map[site_func]
 
     assert result == expected


### PR DESCRIPTION
Fixes #220. For software installed by and managed by Homebrew, `site_data_dir` and `site_config_dir` should point to the Homebrew-managed directories. (I added `site_cache_dir` as well just because it was easy to add.) This also means that the `multipath` option is now relevant for software running on macOS, as well as Linux/Unix.

Note that Homebrew actually has _three_ default prefixes: [one for Intel macOS computers, one for Apple Silicon macOS computers, and one for Linux computers](https://docs.brew.sh/FAQ#why-should-i-install-homebrew-in-the-default-location). This pull request only addresses Apple Silicon macOS computers, where the default prefix is `/opt/homebrew`. I did this for several reasons:

1. On macOS, `/opt/homebrew` is the clearest indication that the software is indeed running under Homebrew; `/usr/local` could mean user-installed software.
2. It will probably be awhile before this change affects end-users; by that time, Intel Macs may no longer be supported.
3. Very, very few people use Homebrew on Linux; it doesn't seem worth it to support that use-case (yet).

Thoughts?