### PR TITLE
site_cache_dir: Use `/var/cache` again instead of `/var/tmp` on UNIX

### DIFF
--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -99,8 +99,8 @@ class Unix(PlatformDirsABC):
 
     @property
     def site_cache_dir(self) -> str:
-        """:return: cache directory shared by users, e.g. ``/var/tmp/$appname/$version``"""
-        return self._append_app_name_and_version("/var/tmp")  # noqa: S108
+        """:return: cache directory shared by users, e.g. ``/var/cache/$appname/$version``"""
+        return self._append_app_name_and_version("/var/cache")
 
     @property
     def user_state_dir(self) -> str:


### PR DESCRIPTION
This directory was changed from `/var/cache` to `/var/tmp` in #148 due to permissions issues. However, `/var/tmp` is an insecure location to store anything with a predictable filename, because any other user could have written it first. This leads to vulnerabilities categorized under [CWE-377](https://cwe.mitre.org/data/definitions/377.html) and [CAPEC-149](https://capec.mitre.org/data/definitions/149.html).

To deal with the permissions issues, applications should put their own cache data in a subdirectory of `/var/cache` (e.g. `/var/cache/cups`), and the application’s package is responsible for ensuring the subdirectory exists and giving it the correct permissions.