### PR TITLE
chore: update dead Microsoft's known folders documentation link

### DIFF
--- a/src/platformdirs/windows.py
+++ b/src/platformdirs/windows.py
@@ -16,8 +16,7 @@ if TYPE_CHECKING:
 
 class Windows(PlatformDirsABC):
     """
-    `MSDN on where to store app data files <https://support.microsoft.com/default.aspx?scid=kb;en-
-    us;310294#XSLTH3194121123120121120120>`_.
+    `MSDN on where to store app data files <https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid>`_.
 
     Makes use of the `appname <platformdirs.api.PlatformDirsABC.appname>`, `appauthor
     <platformdirs.api.PlatformDirsABC.appauthor>`, `version <platformdirs.api.PlatformDirsABC.version>`, `roaming


### PR DESCRIPTION
Follow-up to #263, in which Ofek's new link suggestion for Microsoft "Known Folders" documentation was not integrated into the PR before it was merged.