### PR TITLE
Allow working without ctypes

### DIFF
--- a/src/platformdirs/windows.py
+++ b/src/platformdirs/windows.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import ctypes
 import os
 import sys
 from functools import lru_cache
@@ -217,6 +216,8 @@ def get_win_folder_via_ctypes(csidl_name: str) -> str:
     # Use 'CSIDL_PROFILE' (40) and append the default folder 'Downloads' instead.
     # https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid
 
+    import ctypes  # noqa: PLC0415
+
     csidl_const = {
         "CSIDL_APPDATA": 26,
         "CSIDL_COMMON_APPDATA": 35,
@@ -249,8 +250,13 @@ def get_win_folder_via_ctypes(csidl_name: str) -> str:
 
 
 def _pick_get_win_folder() -> Callable[[str], str]:
-    if hasattr(ctypes, "windll"):
-        return get_win_folder_via_ctypes
+    try:
+        import ctypes  # noqa: PLC0415
+    except ImportError:
+        pass
+    else:
+        if hasattr(ctypes, "windll"):
+            return get_win_folder_via_ctypes
     try:
         import winreg  # noqa: PLC0415, F401
     except ImportError:


### PR DESCRIPTION
ctypes in windows is perfectly optional, but it doesn't fall back to other methods when `import ctypes` fails.