### PR TITLE
Fix android detection when python4android is present

### DIFF
--- a/src/platformdirs/android.py
+++ b/src/platformdirs/android.py
@@ -120,8 +120,8 @@ class Android(PlatformDirsABC):
 def _android_folder() -> str | None:  # noqa: C901, PLR0912
     """:return: base folder for the Android OS or None if it cannot be found"""
     result: str | None = None
-    # type checker isn't happy with our "import android", just don't do this when type checking
-    # see https://stackoverflow.com/a/61394121
+    # type checker isn't happy with our "import android", just don't do this when type checking see
+    # https://stackoverflow.com/a/61394121
     if not TYPE_CHECKING:
         try:
             # First try to get a path to android app using python4android (if available)...
@@ -152,8 +152,8 @@ def _android_folder() -> str | None:  # noqa: C901, PLR0912
         else:
             result = None
     if result is None:
-        # one last try: find an android folder looking at path on the sys.path
-        # taking adopted storage paths into account
+        # one last try: find an android folder looking at path on the sys.path taking adopted storage paths into
+        # account
         pattern = re.compile(r"/mnt/expand/[a-fA-F0-9-]{36}/(data|user/\d+)/(.+)/files")
         for path in sys.path:
             if pattern.match(path):

--- a/src/platformdirs/android.py
+++ b/src/platformdirs/android.py
@@ -6,7 +6,7 @@ import os
 import re
 import sys
 from functools import lru_cache
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from .api import PlatformDirsABC
 
@@ -119,14 +119,31 @@ class Android(PlatformDirsABC):
 @lru_cache(maxsize=1)
 def _android_folder() -> str | None:
     """:return: base folder for the Android OS or None if it cannot be found"""
-    try:
-        # First try to get a path to android app via pyjnius
-        from jnius import autoclass  # noqa: PLC0415
+    result: str | None = None
+    # type checker isn't happy with our "import android", just don't do this when type checking
+    # see https://stackoverflow.com/a/61394121
+    if not TYPE_CHECKING:
+        try:
+            # First try to get a path to android app using python4android (if available)...
+            from android import mActivity  # noqa: PLC0415
 
-        context = autoclass("android.content.Context")
-        result: str | None = context.getFilesDir().getParentFile().getAbsolutePath()
-    except Exception:  # noqa: BLE001
-        # if fails find an android folder looking a path on the sys.path
+            context = cast("android.content.Context", mActivity.getApplicationContext())  # noqa: F821
+            result = context.getFilesDir().getParentFile().getAbsolutePath()
+        except Exception:  # noqa: BLE001
+            result = None
+    if result is None:
+        try:
+            # ...and fall back to using plain pyjnius, if python4android isn't
+            # available or doesn't deliver any useful result...
+            from jnius import autoclass  # noqa: PLC0415
+
+            context = autoclass("android.content.Context")
+            result = context.getFilesDir().getParentFile().getAbsolutePath()
+        except Exception:  # noqa: BLE001
+            result = None
+    if result is None:
+        # and if that fails, too, find an android folder looking at path on the sys.path
+        # warning: only works for apps installed under /data, not adopted storage etc.
         pattern = re.compile(r"/data/(data|user/\d+)/(.+)/files")
         for path in sys.path:
             if pattern.match(path):

--- a/src/platformdirs/android.py
+++ b/src/platformdirs/android.py
@@ -151,6 +151,16 @@ def _android_folder() -> str | None:
                 break
         else:
             result = None
+    if result is None:
+        # one last try: find an android folder looking at path on the sys.path
+        # taking adopted storage paths into acount
+        pattern = re.compile(r"/mnt/expand/[a-fA-F0-9-]{36}/(data|user/\d+)/(.+)/files")
+        for path in sys.path:
+            if pattern.match(path):
+                result = path.split("/files")[0]
+                break
+        else:
+            result = None
     return result
 
 

--- a/src/platformdirs/android.py
+++ b/src/platformdirs/android.py
@@ -133,8 +133,8 @@ def _android_folder() -> str | None:  # noqa: C901, PLR0912
             result = None
     if result is None:
         try:
-            # ...and fall back to using plain pyjnius, if python4android isn't
-            # available or doesn't deliver any useful result...
+            # ...and fall back to using plain pyjnius, if python4android isn't available or doesn't deliver any useful
+            # result...
             from jnius import autoclass  # noqa: PLC0415
 
             context = autoclass("android.content.Context")

--- a/src/platformdirs/android.py
+++ b/src/platformdirs/android.py
@@ -117,7 +117,7 @@ class Android(PlatformDirsABC):
 
 
 @lru_cache(maxsize=1)
-def _android_folder() -> str | None:
+def _android_folder() -> str | None:  # noqa: C901, PLR0912
     """:return: base folder for the Android OS or None if it cannot be found"""
     result: str | None = None
     # type checker isn't happy with our "import android", just don't do this when type checking
@@ -153,7 +153,7 @@ def _android_folder() -> str | None:
             result = None
     if result is None:
         # one last try: find an android folder looking at path on the sys.path
-        # taking adopted storage paths into acount
+        # taking adopted storage paths into account
         pattern = re.compile(r"/mnt/expand/[a-fA-F0-9-]{36}/(data|user/\d+)/(.+)/files")
         for path in sys.path:
             if pattern.match(path):

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -104,19 +104,19 @@ def test_android_folder_from_p4a(mocker: MockerFixture, monkeypatch: pytest.Monk
 
     _android_folder.cache_clear()
 
-    abspath = MagicMock(return_value="/A")  # pragma: no cover
-    pfile = MagicMock(getAbsolutePath=abspath)  # pragma: no cover
-    fdir = MagicMock(getParentFile=MagicMock(return_value=pfile))  # pragma: no cover
-    appc = MagicMock(getFilesDir=MagicMock(return_value=fdir))  # pragma: no cover
-    act = MagicMock(getApplicationContext=MagicMock(return_value=appc))  # pragma: no cover
-    mocker.patch.dict(sys.modules, {"android": MagicMock(mActivity=act)})  # pragma: no cover
+    get_absolute_path = MagicMock(return_value="/A")
+    get_parent_file = MagicMock(getAbsolutePath=get_absolute_path)
+    get_files_dir = MagicMock(getParentFile=MagicMock(return_value=get_parent_file))
+    get_application_context = MagicMock(getFilesDir=MagicMock(return_value=get_files_dir))
+    m_activity = MagicMock(getApplicationContext=MagicMock(return_value=get_application_context))
+    mocker.patch.dict(sys.modules, {"android": MagicMock(mActivity=m_activity)})
 
     result = _android_folder()
     assert result == "/A"
-    assert abspath.call_count == 1
+    assert get_absolute_path.call_count == 1
 
     assert _android_folder() is result
-    assert abspath.call_count == 1
+    assert get_absolute_path.call_count == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -104,19 +104,19 @@ def test_android_folder_from_p4a(mocker: MockerFixture, monkeypatch: pytest.Monk
 
     _android_folder.cache_clear()
 
-    getAbsolutePath = MagicMock(return_value="/A")  # pragma: no cover
-    getParentFile = MagicMock(getAbsolutePath=getAbsolutePath)  # pragma: no cover
-    getFilesDir = MagicMock(getParentFile=MagicMock(return_value=getParentFile))  # pragma: no cover
-    getApplicationContext = MagicMock(getFilesDir=MagicMock(return_value=getFilesDir))  # pragma: no cover
-    mActivity = MagicMock(getApplicationContext=MagicMock(return_value=getApplicationContext))  # pragma: no cover
-    mocker.patch.dict(sys.modules, {"android": MagicMock(mActivity=mActivity)})  # pragma: no cover
+    abspath = MagicMock(return_value="/A")  # pragma: no cover
+    pfile = MagicMock(getAbsolutePath=abspath)  # pragma: no cover
+    fdir = MagicMock(getParentFile=MagicMock(return_value=pfile))  # pragma: no cover
+    appc = MagicMock(getFilesDir=MagicMock(return_value=fdir))  # pragma: no cover
+    act = MagicMock(getApplicationContext=MagicMock(return_value=appc))  # pragma: no cover
+    mocker.patch.dict(sys.modules, {"android": MagicMock(mActivity=act)})  # pragma: no cover
 
     result = _android_folder()
     assert result == "/A"
-    assert getAbsolutePath.call_count == 1
+    assert abspath.call_count == 1
 
     assert _android_folder() is result
-    assert getAbsolutePath.call_count == 1
+    assert abspath.call_count == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -72,7 +72,7 @@ def test_android_folder_from_jnius(mocker: MockerFixture, monkeypatch: pytest.Mo
     from platformdirs.android import _android_folder  # noqa: PLC0415
 
     mocker.patch.dict(sys.modules, {"android": MagicMock(side_effect=ModuleNotFoundError)})
-    monkeypatch.delitem(__import__('sys').modules, 'android')
+    monkeypatch.delitem(__import__("sys").modules, "android")
 
     _android_folder.cache_clear()
 
@@ -95,19 +95,19 @@ def test_android_folder_from_jnius(mocker: MockerFixture, monkeypatch: pytest.Mo
     assert _android_folder() is result
     assert autoclass.call_count == 1
 
+
 def test_android_folder_from_p4a(mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch) -> None:
-    from platformdirs import PlatformDirs  # noqa: PLC0415
     from platformdirs.android import _android_folder  # noqa: PLC0415
 
     mocker.patch.dict(sys.modules, {"jnius": MagicMock(side_effect=ModuleNotFoundError)})
-    monkeypatch.delitem(__import__('sys').modules, 'jnius')
+    monkeypatch.delitem(__import__("sys").modules, "jnius")
 
     _android_folder.cache_clear()
 
     getAbsolutePath = MagicMock(return_value="/A")  # pragma: no cover
     getParentFile = MagicMock(getAbsolutePath=getAbsolutePath)  # pragma: no cover
     getFilesDir = MagicMock(getParentFile=MagicMock(return_value=getParentFile))  # pragma: no cover
-    getApplicationContext = MagicMock(getFilesDir = MagicMock(return_value=getFilesDir))  # pragma: no cover
+    getApplicationContext = MagicMock(getFilesDir=MagicMock(return_value=getFilesDir))  # pragma: no cover
     mActivity = MagicMock(getApplicationContext=MagicMock(return_value=getApplicationContext))  # pragma: no cover
     mocker.patch.dict(sys.modules, {"android": MagicMock(mActivity=mActivity)})  # pragma: no cover
 
@@ -117,6 +117,7 @@ def test_android_folder_from_p4a(mocker: MockerFixture, monkeypatch: pytest.Monk
 
     assert _android_folder() is result
     assert getAbsolutePath.call_count == 1
+
 
 @pytest.mark.parametrize(
     "path",
@@ -128,9 +129,9 @@ def test_android_folder_from_p4a(mocker: MockerFixture, monkeypatch: pytest.Monk
 )
 def test_android_folder_from_sys_path(mocker: MockerFixture, path: str, monkeypatch: pytest.MonkeyPatch) -> None:
     mocker.patch.dict(sys.modules, {"jnius": MagicMock(side_effect=ModuleNotFoundError)})
-    monkeypatch.delitem(__import__('sys').modules, 'jnius')
+    monkeypatch.delitem(__import__("sys").modules, "jnius")
     mocker.patch.dict(sys.modules, {"android": MagicMock(side_effect=ModuleNotFoundError)})
-    monkeypatch.delitem(__import__('sys').modules, 'android')
+    monkeypatch.delitem(__import__("sys").modules, "android")
 
     from platformdirs.android import _android_folder  # noqa: PLC0415
 


### PR DESCRIPTION
When using **platformdirs** in an android app located on adopted storage, `_android_folder()` in `android.py` returned `None` which lead **platformdirs** to believe that it doesn't run on android and use the `Unix` flavor instead.

In [android.py#L126](https://github.com/platformdirs/platformdirs/blob/main/src/platformdirs/android.py#L126) `autoclass("android.content.Context")` returns a class instead of an instance, which throws an exception on the next line trying to access an instance method named `getFilesDir()`.

That exception is catched and a fallback implementation invoked, that uses a regular expression to search in `sys.path` for an import path rooted in `/data`. Apps installed on adopted storage don't have such paths but begin with `/mnt/expand/` instead.
The regular expression therefore fails and `_android_folder()` returns `None`.

This pull request fixes the issue at least for cases where python4android is available, by first trying to import the `android` module and using it's `mActivity` export to get hold of the main activity. That activity is then used to get a proper application context upon which `getFilesDir()` can be invoked.

If that fails with an exception the original codepath is taken, trying the `autoclass`approach next and if that fails resorting to the regular expression.