### PR TITLE
Ensure PlatformDirs is valid superclass type for mypy AND not an abstract class for other checkers

### DIFF
--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -19,8 +19,6 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Literal
 
-    from typing_extensions import TypeAlias
-
 if sys.platform == "win32":
     from platformdirs.windows import Windows as _Result
 elif sys.platform == "darwin":
@@ -46,7 +44,7 @@ def _set_platform_dir_class() -> type[PlatformDirsABC]:
 
 if TYPE_CHECKING:
     # Work around mypy issue: https://github.com/python/mypy/issues/10962
-    PlatformDirs: TypeAlias = _Result
+    PlatformDirs = _Result
 else:
     PlatformDirs = _set_platform_dir_class()  #: Currently active platform
 AppDirs = PlatformDirs  #: Backwards compatibility with appdirs

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Literal
 
+    from typing_extensions import TypeAlias
+
 
 def _set_platform_dir_class() -> type[PlatformDirsABC]:
     if sys.platform == "win32":
@@ -42,7 +44,11 @@ def _set_platform_dir_class() -> type[PlatformDirsABC]:
     return Result
 
 
-PlatformDirs = _set_platform_dir_class()  #: Currently active platform
+if TYPE_CHECKING:
+    # Work around mypy issue: https://github.com/python/mypy/issues/10962
+    PlatformDirs: TypeAlias = PlatformDirsABC
+else:
+    PlatformDirs = _set_platform_dir_class()  #: Currently active platform
 AppDirs = PlatformDirs  #: Backwards compatibility with appdirs
 
 

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -21,18 +21,18 @@ if TYPE_CHECKING:
 
     from typing_extensions import TypeAlias
 
+if sys.platform == "win32":
+    from platformdirs.windows import Windows as _Result
+elif sys.platform == "darwin":
+    from platformdirs.macos import MacOS as _Result
+else:
+    from platformdirs.unix import Unix as _Result
+
 
 def _set_platform_dir_class() -> type[PlatformDirsABC]:
-    if sys.platform == "win32":
-        from platformdirs.windows import Windows as Result  # noqa: PLC0415
-    elif sys.platform == "darwin":
-        from platformdirs.macos import MacOS as Result  # noqa: PLC0415
-    else:
-        from platformdirs.unix import Unix as Result  # noqa: PLC0415
-
     if os.getenv("ANDROID_DATA") == "/data" and os.getenv("ANDROID_ROOT") == "/system":
         if os.getenv("SHELL") or os.getenv("PREFIX"):
-            return Result
+            return _Result
 
         from platformdirs.android import _android_folder  # noqa: PLC0415
 
@@ -41,12 +41,12 @@ def _set_platform_dir_class() -> type[PlatformDirsABC]:
 
             return Android  # return to avoid redefinition of a result
 
-    return Result
+    return _Result
 
 
 if TYPE_CHECKING:
     # Work around mypy issue: https://github.com/python/mypy/issues/10962
-    PlatformDirs: TypeAlias = PlatformDirsABC
+    PlatformDirs: TypeAlias = _Result
 else:
     PlatformDirs = _set_platform_dir_class()  #: Currently active platform
 AppDirs = PlatformDirs  #: Backwards compatibility with appdirs

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -76,7 +76,7 @@ def test_android_folder_from_jnius(mocker: MockerFixture, monkeypatch: pytest.Mo
 
     _android_folder.cache_clear()
 
-    if PlatformDirs is Android:
+    if PlatformDirs is Android:  # type: ignore[comparison-overlap] # See https://github.com/platformdirs/platformdirs/pull/295
         import jnius  # pragma: no cover # noqa: PLC0415
 
         autoclass = mocker.spy(jnius, "autoclass")  # pragma: no cover

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -121,3 +121,12 @@ def test_no_ctypes() -> None:
     import platformdirs  # noqa: PLC0415
 
     assert platformdirs
+
+
+def test_mypy_subclassing() -> None:
+    # Ensure that PlatformDirs / AppDirs is seen as a valid superclass by mypy
+    # This is a static type-checking test to ensure we work around
+    # the following mypy issue: https://github.com/python/mypy/issues/10962
+    class PlatformDirsSubclass(platformdirs.PlatformDirs): ...
+
+    class AppDirsSubclass(platformdirs.AppDirs): ...


### PR DESCRIPTION
This was spotted in https://github.com/jaraco/jaraco.abode/blob/8843f360ee5d9bc1afb1bdb3119157addb4aaf06/jaraco/abode/config.py#L4C7-L4C19 / https://github.com/jaraco/skeleton/pull/136#issuecomment-2303602369

Trying to subclass `PlatformDirs` (and by extension, `AppDirs`) results in the following error with mypy:
`Variable "platformdirs.PlatformDirs" is not valid as a type`
This is a known issue: https://github.com/python/mypy/issues/10962

Thankfully it can be worked around, which this PR does, as well as adding a static test for it.

---

Then another issue is revealed, since `PlatformDirs` is typed as being an abstract class, it shouldn't be allowed to be instantiated ! So I can't just do:
```py
if TYPE_CHECKING:
    # Work around mypy issue: https://github.com/python/mypy/issues/10962
    PlatformDirs: TypeAlias = PlatformDirsABC
else:
    PlatformDirs = _set_platform_dir_class()  #: Currently active platform
```

I'm honnestly a bit dumbofunded by that one. It's a perfect unfixeable storm.

I can't type `PlatformDirs` as a `TypeAlias` of `type[Result] | type[Android]` because we're right back to square one.
And without https://peps.python.org/pep-0738/ I can't just alias `PlatformDirs` to `Result` otherwise `if PlatformDirs is Android` will always be raised as an issue by type_checkers. Same if I make `PlatformDirs` a fake subclass of `PlatformDirsABC` in the `TYPE_CHECKING` block.

I think the false positive on `if PlatformDirs is Android` is probably much better than a false positive on `class MySubclass(PlatformDirs): ...` So I'll go for that.