### PR TITLE
Use `include-hidden-files: true` to upload coverage artifacts

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Upload coverage data
         uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: coverage-${{ matrix.os }}-${{ matrix.py }}
           path: "report/.coverage.*"
           retention-days: 3


### PR DESCRIPTION
Version [v4.4.0](https://github.com/actions/upload-artifact/releases/tag/v4.4.0) of actions/upload-artifact broke uploading (silently) and combining coverage files.
